### PR TITLE
add gitattributes to reduce composer package size 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/tests export-ignore
+/banner.png export-ignore
+/permissions.png export-ignore

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./banner.png">
+![Runway](https://raw.githubusercontent.com/doublethreedigital/runway/master/banner.png)
 
 # Runway
 


### PR DESCRIPTION
adding all files to .gitattributes, which the composer package don't need.

Should always include:
- Pipline/Github Actions
- Tests Files
- Docs
- etc.