### PR TITLE
Fix for custom $primaryKey

### DIFF
--- a/src/Support/ModelFinder.php
+++ b/src/Support/ModelFinder.php
@@ -39,7 +39,7 @@ class ModelFinder
                     'listing_columns'   => $config['listing']['columns'],
                     'listing_sort'      => $config['listing']['sort'],
                     'primary_key'       => $eloquentModel->getKeyName(),
-                    'route_key'         => $eloquentModel->getRouteKey() ?? 'id',
+                    'route_key'         => $eloquentModel->getRouteKeyName() ?? 'id',
                     'model_table'       => $modelTable,
                     'schema_columns'    => $schemaColumns,
                     'cp_icon'           => isset($config['listing']['cp_icon'])


### PR DESCRIPTION
On a Model with a custom $primaryKey set, I get the following error on its index page:

`Illuminate\Routing\Exceptions\UrlGenerationException
Missing required parameter for [Route: statamic.cp.runway.edit] [URI: cp/runway/{model}/{record}] [Missing parameter: record]. (View: vendor/doublethreedigital/runway/resources/views/index.blade.php)
 `

Changing to [getRouteKeyName()](https://laravel.com/api/8.x/Illuminate/Database/Eloquent/Model.html#method_getRouteKeyName) instead of `getRouteKey()` fixes the error for me.