### PR TITLE
Custom $primaryKey fixes

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -112,7 +112,7 @@ class BaseFieldtype extends Relationship
         $record = $resource->model()->firstWhere($resource->primaryKey(), $id);
 
         return [
-            'id'    => $record->id,
+            'id'    => $record->getKey(),
             'title' => $record->{collect($resource->listingColumns())->first()},
         ];
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -183,7 +183,7 @@ class Resource
 
     public function routeKey()
     {
-        return $this->model()->getRouteKey() ?? 'id';
+        return $this->model()->getRouteKeyName() ?? 'id';
     }
 
     public function databaseTable()


### PR DESCRIPTION
## Description

1. Fixes resource index when the resource model has a custom `$primaryKey` (or `getRouteKeyName()`).
2. Fixes BelongsTo fieldtype item data when the resource model uses a custom $primaryKey.

## Related Issues

<!-- 
  Does this PR fix an open issue? 
  Link it with a keyword: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

