### PR TITLE
Fix prop issue in ListingVue

### DIFF
--- a/resources/js/components/Listing/ListingView.vue
+++ b/resources/js/components/Listing/ListingView.vue
@@ -127,7 +127,7 @@ export default {
     mixins: [Listing],
 
     props: {
-        listingConfig: Array,
+        listingConfig: Object,
         columns: Array,
         actionUrl: String,
     },


### PR DESCRIPTION
## Description

Listing config should be an object, since it's used as one.
