### PR TITLE
Use date field's own format to edit the resource

### DIFF
--- a/src/AugmentedRecord.php
+++ b/src/AugmentedRecord.php
@@ -19,10 +19,9 @@ class AugmentedRecord
                 $value = $record->{$key} ?? $value;
 
                 if ($value instanceof CarbonInterface) {
-                    $field = $resource->blueprint()->field($key);
-
                     $format = $defaultFormat = 'Y-m-d H:i';
-                    if ($field) {
+
+                    if ($field = $resource->blueprint()->field($key)) {
                         $format = $field->get('format', $defaultFormat);
                     }
 

--- a/src/AugmentedRecord.php
+++ b/src/AugmentedRecord.php
@@ -14,9 +14,19 @@ class AugmentedRecord
         $resource = Runway::findResourceByModel($record);
 
         return collect($record)
-            ->map(function ($value, $key) use ($blueprint) {
+            ->map(function ($value, $key) use ($record, $resource, $blueprint) {
+
+                $value = $record->{$key} ?? $value;
+
                 if ($value instanceof CarbonInterface) {
-                    return $value->format('Y-m-d H:i');
+                    $field = $resource->blueprint()->field($key);
+
+                    $format = $defaultFormat = 'Y-m-d H:i';
+                    if ($field) {
+                        $format = $field->get('format', $defaultFormat);
+                    }
+
+                    return $value->format($format);
                 }
 
                 if (Json::isJson($value)) {

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -104,7 +104,12 @@ class ResourceController extends CpController
             $value = $record->{$fieldKey};
 
             if ($value instanceof \Carbon\Carbon) {
-                $value = $value->format('Y-m-d H:i');
+                $format = 'Y-m-d H:i:s';
+                $field = $resource->blueprint()->field($fieldKey);
+                if ($field && $field->get('format')) {
+                    $format = $field->get('format');
+                }
+                $value = $value->format($format);
             }
 
             if (Json::isJson($value)) {

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -10,10 +10,8 @@ use DoubleThreeDigital\Runway\Http\Requests\UpdateRequest;
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Support\Json;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Facades\Scope;
-use Statamic\Fieldtypes\Date;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ResourceController extends CpController
@@ -106,11 +104,9 @@ class ResourceController extends CpController
             $value = $record->{$fieldKey};
 
             if ($value instanceof \Carbon\Carbon) {
-                /** @var Date $field */
-                $field = $resource->blueprint()->field($fieldKey);
                 $format = $defaultFormat = 'Y-m-d H:i';
 
-                if ($field) {
+                if ($field = $resource->blueprint()->field($fieldKey)) {
                     $format = $field->get('format', $defaultFormat);
                 }
 

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -10,8 +10,10 @@ use DoubleThreeDigital\Runway\Http\Requests\UpdateRequest;
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Support\Json;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Facades\Scope;
+use Statamic\Fieldtypes\Date;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ResourceController extends CpController
@@ -104,11 +106,14 @@ class ResourceController extends CpController
             $value = $record->{$fieldKey};
 
             if ($value instanceof \Carbon\Carbon) {
-                $format = 'Y-m-d H:i:s';
+                /** @var Date $field */
                 $field = $resource->blueprint()->field($fieldKey);
-                if ($field && $field->get('format')) {
-                    $format = $field->get('format');
+                $format = $defaultFormat = 'Y-m-d H:i';
+
+                if ($field) {
+                    $format = $field->get('format', $defaultFormat);
                 }
+
                 $value = $value->format($format);
             }
 

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -2,6 +2,9 @@
 
 namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
 
+use DoubleThreeDigital\Runway\Resource;
+use DoubleThreeDigital\Runway\Runway;
+use DoubleThreeDigital\Runway\Tests\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Statamic\Facades\User;
@@ -114,5 +117,68 @@ class ResourceControllerTest extends TestCase
         $this->assertDatabaseMissing('posts', [
             'id' => $post->id,
         ]);
+    }
+
+    /**
+     * @test
+     * @dataProvider dateTimeProvider
+     */
+    public function can_edit_resource_with_datetime_field(array $options)
+    {
+        // Override the config to add the created_at field
+        $configKey = 'runway.resources.' . Post::class . '.blueprint.sections.main.fields';
+        $fields = $this->app['config']->get($configKey, []);
+        $fields[] = [
+            'handle' => 'created_at',
+            'field'  => array_filter($options),
+        ];
+        $this->app['config']->set($configKey, $fields);
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $post = $this->postFactory();
+        /** @var Resource $resource */
+        $resource = Runway::findResource('post');
+        $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
+
+        $this->assertEquals($post->getKey(), $record->getKey());
+
+        $response = $this->actingAs($user)
+            ->get(cp_route('runway.edit', [
+                'resourceHandle' => 'post',
+                'record'         => $post->id
+            ]))
+            ->assertOk();
+
+        $this->assertEquals(
+            $post->created_at->format($options['expected_format'] ?? $options['format'] ??  'Y-m-d'),
+            $response->viewData('values')->get('created_at')
+        );
+    }
+
+    public function dateTimeProvider()
+    {
+        return [
+            'simple_date' => [[
+                'type' => 'date',
+                'format' => null,
+                'time_enabled' => false,
+                'time_required' => false,
+            ]],
+            'simple_date_with_default_format' => [[
+                'type' => 'date',
+                'format' => 'Y-m-d',
+                'time_enabled' => false,
+                'time_required' => false,
+            ]],
+            'datetime_with_format' => [[
+                'type' => 'date',
+                'format' => 'Y-m-d H:i:s',
+                'expected_format' => 'Y-m-d H:i',
+                'time_enabled' => true,
+                'time_required' => false,
+            ]]
+        ];
     }
 }


### PR DESCRIPTION
## Description

When editing a Date field, let's use the user defined format if set, or a sensible default if not

