### PR TITLE
Fix conflicting props / data name for columns

### DIFF
--- a/resources/js/components/Listing/ListingView.vue
+++ b/resources/js/components/Listing/ListingView.vue
@@ -128,15 +128,15 @@ export default {
 
     props: {
         listingConfig: Array,
-        columns: Array,
+        initialColumns: Array,
         actionUrl: String,
     },
 
     data() {
         let primaryColumn = ''
 
-        if (this.columns) {
-            this.columns.forEach((column) => {
+        if (this.initialColumns) {
+            this.initialColumns.forEach((column) => {
                 if (column.has_link)
                     primaryColumn = column.handle
                 }
@@ -147,7 +147,7 @@ export default {
             listingKey: 'id',
             preferencesPrefix: this.listingConfig.preferencesPrefix ?? 'runway',
             requestUrl: this.listingConfig.requestUrl,
-            columns: this.columns,
+            columns: this.initialColumns,
             meta: {},
             primaryColumn: `cell-${primaryColumn}`,
             deletingRow: false,

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -18,7 +18,7 @@
         <runway-listing-view
             :filters="{{ $filters->toJson() }}"
             :listing-config='@json($listingConfig)'
-            :columns='@json($columns)'
+            :initial-columns='@json($columns)'
             action-url="{{ $actionUrl }}"
         ></runway-listing-view>
      @else


### PR DESCRIPTION
## Description

Columns is a data name already use by the parent `Listing` vue component.
Let's rename the prop to `initialColumns` to avoid conflicts

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

