### PR TITLE
don't json encode casted properties

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -138,7 +138,7 @@ class ResourceController extends CpController
             'meta'      => $fields->meta(),
             'action'    => cp_route('runway.update', [
                 'resourceHandle'  => $resource->handle(),
-                'record' => $record->{$resource->primaryKey()},
+                'record' => $record->{$resource->routeKey()},
             ]),
             'permalink' => $resource->hasRouting()
                 ? $record->uri()


### PR DESCRIPTION
## Description

If in a model there is a casted property like array, collection, object, we don't need to json encode it, otherwise the caster will "double encode it"

