### PR TITLE
Null check on $record in toItemArray()

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -155,11 +155,12 @@ class BaseFieldtype extends Relationship
         } else {
             $record = $id;
         }
-        
-        if (is_null($record)) {
+
+        if (! $record) {
             return [
                 'id' => $id,
-                'title' => $id . ' (not found)',
+                'title' => $id,
+                'invalid' => true,
             ];
         }
 

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -155,6 +155,13 @@ class BaseFieldtype extends Relationship
         } else {
             $record = $id;
         }
+        
+        if (is_null($record)) {
+            return [
+                'id' => $id,
+                'title' => $id . ' (not found)',
+            ];
+        }
 
         return [
             'id'    => $record->getKey(),


### PR DESCRIPTION
## Description

When a relationship field contains a record which has been deleted, the entry publish form errors with `Call to a member function getKey() on null` at line 160.

This adds a null check on $record and returns the title as '[id] (not found)'.

## Related Issues

n/a

