### PR TITLE
Generate blueprints from database

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -49,9 +49,9 @@ The next thing you’ll want to do is create a blueprint for your model.
 ### Creating a new blueprint
 Unfortunately, you can’t yet create/edit blueprints used for Runway in the Control Panel but it’s something we’re hoping comes in the future (it’s a Statamic Core change).
 
-However, we can workaround it for now. Instead, create a new blueprint for one of your collections, taxonomies etc (it doesn’t matter). 
+However, we can workaround it for now. Instead, create a new blueprint for one of your collections, taxonomies etc (it doesn’t matter).
 
-When creating it, add in all the fields you need. Remember that the field handles need to match up with the column names, otherwise bad things will happen. 
+When creating it, add in all the fields you need. Remember that the field handles need to match up with the column names, otherwise bad things will happen.
 
 Once created via the CP, you’ll find the blueprint’s YAML file in a folder somewhere, probably something like `resources/blueprints/collections/pages/my-special-blueprint.yaml`.
 
@@ -93,6 +93,24 @@ You may also run this same command for all resources pending a migration.
 php please runway:generate-migrations
 ```
 
+### Generating blueprints from your database
+If you've already got an Eloquent model setup, Runway can help you turn it into a blueprint!
+
+Before you can generate, you'll need to install the [`doctrine/dbal`](https://github.com/doctrine/dbal) package as it'll be used by Runway to analyse your database columns. You'll also need to have migrated your database already.
+
+As well as having your model setup, you will also need to add the resource(s) to your `config/runway.php` config.
+
+To generate a blueprint for a specific resource:
+
+```
+php please runway:generate-blueprints resource-handle
+```
+
+You may also run this same command for all resources:
+
+```
+php please runway:generate-blueprints
+```
 
 ## Configuring resources
 There’s about a dozen configuration options available for resources, they are all documented below.
@@ -111,7 +129,7 @@ If you’d like to hide the CP Nav Item that’s registered for this model, just
 ],
 ```
 
-> Bear in mind, this will just hide the Nav Item for the CP interface, it won’t actually get rid of the routes being registered. If someone knows where to look, they could still use the CP to manage your models (they could guess the URL).  
+> Bear in mind, this will just hide the Nav Item for the CP interface, it won’t actually get rid of the routes being registered. If someone knows where to look, they could still use the CP to manage your models (they could guess the URL).
 
 
 ### CP Nav Icon
@@ -164,7 +182,7 @@ You may also specify the `template` and `layout` you want to use when front-end 
 ## Actions
 In much the same way with entries, you can create custom Actions which will be usable in the listing tables provided by Runway.
 
-You can register them in the same way as you normally would. 
+You can register them in the same way as you normally would.
 
 The only thing that’s different is the fact that instead of filtering down to just `Entry` objects for example, you can filter by your model, like `Order`.
 

--- a/src/Console/Commands/GenerateBlueprint.php
+++ b/src/Console/Commands/GenerateBlueprint.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Console\Commands;
+
+use DoubleThreeDigital\Runway\Resource;
+use DoubleThreeDigital\Runway\Runway;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Statamic\Console\RunsInPlease;
+use Illuminate\Support\Str;
+use Statamic\Facades\Blueprint;
+
+class GenerateBlueprint extends Command
+{
+    use RunsInPlease;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'runway:generate-blueprints {resource?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Generate blueprints from your models";
+
+    /**
+     * The matching table for column types -> fieldtypes
+     *
+     * @var array
+     */
+    protected array $matching = [
+        \Doctrine\DBAL\Types\ArrayType::class => [
+            'type' => 'array',
+        ],
+        \Doctrine\DBAL\Types\AsciiType::class => [],
+        \Doctrine\DBAL\Types\BigIntType::class => [
+            'normal' => 'integer',
+        ],
+        \Doctrine\DBAL\Types\BinaryType::class => [],
+        \Doctrine\DBAL\Types\BlobType::class => [],
+        \Doctrine\DBAL\Types\BooleanType::class => [
+            'normal' => 'toggle',
+        ],
+        \Doctrine\DBAL\Types\DateImmutableType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\DateTimeImmutableType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\DateTimeType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\DateTimeTzImmutableType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\DateTimeTzType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\DateType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\DecimalType::class => [
+            'normal' => 'floatval',
+        ],
+        \Doctrine\DBAL\Types\FloatType::class => [
+            'normal' => 'floatval',
+        ],
+        \Doctrine\DBAL\Types\GuidType::class => [],
+        \Doctrine\DBAL\Types\IntegerType::class => [
+            'normal' => 'integer',
+        ],
+        \Doctrine\DBAL\Types\JsonType::class => [
+            'normal' => 'array',
+        ],
+        \Doctrine\DBAL\Types\ObjectType::class => [],
+        \Doctrine\DBAL\Types\PhpDateTimeMappingType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\PhpIntegerMappingType::class => [
+            'normal' => 'integer',
+        ],
+        \Doctrine\DBAL\Types\SimpleArrayType::class => [
+            'normal' => 'array',
+        ],
+        \Doctrine\DBAL\Types\SmallIntType::class => [
+            'normal' => 'integer',
+        ],
+        \Doctrine\DBAL\Types\StringType::class => [
+            'normal' => 'text',
+        ],
+        \Doctrine\DBAL\Types\TextType::class => [
+            'normal' => 'textarea',
+        ],
+        \Doctrine\DBAL\Types\TimeImmutableType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\TimeType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\VarDateTimeImmutableType::class => [
+            'normal' => 'date',
+        ],
+        \Doctrine\DBAL\Types\VarDateTimeType::class => [
+            'normal' => 'date',
+        ],
+    ];
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->info("Generating blueprints...");
+        $this->line("");
+
+        if (! class_exists('Doctrine\DBAL\Exception')) {
+            return $this->line("❌ Failed. Please install `doctrine/dbal` and try again. `composer require doctrine/dbal`");
+        }
+
+        $resources = [];
+
+        if ($resourceHandle = $this->argument('resource')) {
+            $resources[] = Runway::findResource($resourceHandle);
+        }
+
+        if (count($resources) === 0) {
+            Runway::allResources()
+                ->each(function ($resource) use (&$resources) {
+                    $resources[] = $resource;
+                });
+        }
+
+        foreach ($resources as $resource) {
+            $this->generateForResource($resource);
+        }
+
+        $this->info("✔️ Done");
+    }
+
+    protected function generateForResource(Resource $resource)
+    {
+        $errorMessages = [];
+
+        $columns = Schema::getConnection()->getDoctrineSchemaManager()->listTableColumns($resource->databaseTable());
+
+        $fields = collect($columns)
+            ->reject(function (\Doctrine\DBAL\Schema\Column $column) {
+                return $column->getName() === 'id';
+            })
+            ->map(function (\Doctrine\DBAL\Schema\Column $column) {
+                return [
+                    'name' => $column->getName(),
+                    'type' => $this->getMatchingFieldtype($column),
+                    'nullable' => !$column->getNotnull(),
+                    'default' => $column->getDefault(),
+                    'original_column' => $column,
+                ];
+            })
+            ->each(function ($field) use (&$errorMessages) {
+                if (is_null($field['type'])) {
+                    $errorMessages[] = "Column [{$field['name']}] could not be matched with a fieldtype.";
+                }
+            })
+            ->all();
+
+        $this->generateNewBlueprint($resource, $fields);
+
+        if (count($errorMessages) === 0) {
+            $this->line("✔️ {$resource->name()}");
+            $this->line("");
+        } else {
+            $this->line("❌ {$resource->name()}");
+
+            foreach ($errorMessages as $errorMessage) {
+                $this->comment($errorMessage);
+            }
+
+            $this->line("");
+        }
+    }
+
+    protected function getMatchingFieldtype(\Doctrine\DBAL\Schema\Column $column): ?string
+    {
+        $match = isset($this->matching[get_class($column->getType())])
+            ? $this->matching[get_class($column->getType())]
+            : null;
+
+        if (! $match) {
+            return null;
+        }
+
+        return $match['normal'];
+    }
+
+    protected function generateNewBlueprint(Resource $resource, array $fields)
+    {
+        $mainSection = [];
+        $sidebarSection = [];
+
+        $sidebarFields = ['slug', 'uuid', 'created_at', 'updated_at'];
+
+        collect($fields)
+            ->each(function ($field) use (&$mainSection, &$sidebarSection, $sidebarFields) {
+                $fieldContents = [
+                    'handle' => $field['name'],
+                    'field' => [
+                        'type' => $field['type'],
+                        'display' => Str::studly($field['name']),
+                    ],
+                ];
+
+                if (! $field['nullable']) {
+                    $fieldContents['field']['validate'] = 'required';
+                }
+
+                if (in_array($field['name'], $sidebarFields)) {
+                    $sidebarSection[] = $fieldContents;
+                } else {
+                    $mainSection[] = $fieldContents;
+                }
+            });
+
+        Blueprint::make($resource->handle())
+            ->setContents([
+                'sections' => [
+                    'main' => ['fields' => $mainSection],
+                    'sidebar' => ['fields' => $sidebarSection],
+                ],
+            ])
+            ->save();
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,6 +14,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $commands = [
+        Console\Commands\GenerateBlueprint::class,
         Console\Commands\GenerateMigration::class,
         Console\Commands\RebuildUriCache::class,
     ];


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces a feature where Runway can generate blueprints for you, based on your model's database schema.

## Documentation

> I've straight copy/pasted this from the documentation, for an up-to-date version, please [review the latest Runway docs](https://runway.duncanmcclean.com/resources).

Before you can generate, you'll need to install the [`doctrine/dbal`](https://github.com/doctrine/dbal) package as it'll be used by Runway to analyse your database columns. You'll also need to have migrated your database already.

As well as having your model setup, you will also need to add the resource(s) to your `config/runway.php` config.

To generate a blueprint for a specific resource:

```
php please runway:generate-blueprints resource-handle
```

You may also run this same command for all resources:

```
php please runway:generate-blueprints
```

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Closes #58