### PR TITLE
Eloquent scopes with Runway tag

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -28,6 +28,23 @@ You may use the `sort` parameter to adjust the order of the results.
 {{ /runway:post }}
 ```
 
+### Eloquent Scopes
+If you've defined a scope on your Eloquent model and you want to filter by that in your front-end you may use the `scope` parameter.
+
+```php
+public function scopeFood($query)
+{
+    $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
+}
+```
+
+```antlers
+{{ runway:post scope="food" }}
+	<h2>{{ title }}</h2>
+	<p>{{ intro_text }}</p>
+{{ /runway:post }}
+```
+
 ### Filtering
 Just like with the collection tag, you may filter your results like so:
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -32,6 +32,8 @@ You may use the `sort` parameter to adjust the order of the results.
 If you've defined a scope on your Eloquent model and you want to filter by that in your front-end you may use the `scope` parameter.
 
 ```php
+// app/Models/Post.php
+
 public function scopeFood($query)
 {
     $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -47,6 +47,20 @@ public function scopeFood($query)
 {{ /runway:post }}
 ```
 
+If you need to you can provide arguments to the scope like so:
+
+```antlers
+{{ runway:post scope="food:argument" }}
+```
+
+In the above example, `argument` can either be a string or we'll grab it from 'the context' (the available variables) if we can find it.
+
+You may also provide multiple scopes, if that's something you need...
+
+```antlers
+{{ runway:post scope="food:argument|fastfood" }}
+```
+
 ### Filtering
 Just like with the collection tag, you may filter your results like so:
 

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -26,6 +26,10 @@ class RunwayTag extends Tags
 
         $query = $resource->model()->query();
 
+        if ($scope = $this->params->get('scope')) {
+            $query->{$scope}();
+        }
+
         if ($this->params->has('where') && $where = $this->params->get('where')) {
             $query->where(explode(':', $where)[0], explode(':', $where)[1]);
         }

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -26,8 +26,23 @@ class RunwayTag extends Tags
 
         $query = $resource->model()->query();
 
-        if ($scope = $this->params->get('scope')) {
-            $query->{$scope}();
+        if ($scopes = $this->params->get('scope')) {
+            $scopes = explode('|', $scopes);
+
+            foreach ($scopes as $scope) {
+                $scopeName = explode(':', $scope)[0];
+                $scopeArguments = isset(explode(':', $scope)[1])
+                    ? explode(',', explode(':', $scope)[1])
+                    : [];
+
+                foreach ($scopeArguments as $key => $scopeArgument) {
+                    if ($fromContext = $this->context->get($scopeArgument)) {
+                        $scopeArguments[$key] = $fromContext;
+                    }
+                }
+
+                $query->{$scopeName}(...$scopeArguments);
+            }
         }
 
         if ($this->params->has('where') && $where = $this->params->get('where')) {

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -37,6 +37,10 @@ class RunwayTag extends Tags
 
                 foreach ($scopeArguments as $key => $scopeArgument) {
                     if ($fromContext = $this->context->get($scopeArgument)) {
+                        if ($fromContext instanceof \Statamic\Fields\Value) {
+                            $fromContext = $fromContext->raw();
+                        }
+
                         $scopeArguments[$key] = $fromContext;
                     }
                 }

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -67,6 +67,52 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
+    public function can_get_records_with_scope_parameter_and_scope_arguments()
+    {
+        $posts = $this->postFactory(5);
+
+        $posts[0]->update(['title' => 'Pasta']);
+        $posts[2]->update(['title' => 'Apple']);
+        $posts[4]->update(['title' => 'Burger']);
+
+        $this->tag->setContext([
+            'fab' => 'idoo',
+        ]);
+
+        $this->tag->setParameters([
+            'scope' => 'fruit:fab',
+        ]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertSame(1, count($usage));
+        $this->assertSame((string) $usage[0]['title'], 'Apple');
+    }
+
+    /** @test */
+    public function can_get_records_with_scope_parameter_and_scope_arguments_and_multiple_scopes()
+    {
+        $posts = $this->postFactory(5);
+
+        $posts[0]->update(['title' => 'Pasta']);
+        $posts[2]->update(['title' => 'Apple']);
+        $posts[4]->update(['title' => 'Burger']);
+
+        $this->tag->setContext([
+            'fab' => 'idoo',
+        ]);
+
+        $this->tag->setParameters([
+            'scope' => 'food|fruit:fab',
+        ]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertSame(1, count($usage));
+        $this->assertSame((string) $usage[0]['title'], 'Apple');
+    }
+
+    /** @test */
     public function can_get_records_with_where_parameter()
     {
         $posts = $this->postFactory(5);

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -46,6 +46,27 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
+    public function can_get_records_with_scope_parameter()
+    {
+        $posts = $this->postFactory(5);
+
+        $posts[0]->update(['title' => 'Pasta']);
+        $posts[2]->update(['title' => 'Apple']);
+        $posts[4]->update(['title' => 'Burger']);
+
+        $this->tag->setParameters([
+            'scope' => 'food',
+        ]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertSame(3, count($usage));
+        $this->assertSame((string) $usage[0]['title'], 'Pasta');
+        $this->assertSame((string) $usage[1]['title'], 'Apple');
+        $this->assertSame((string) $usage[2]['title'], 'Burger');
+    }
+
+    /** @test */
     public function can_get_records_with_where_parameter()
     {
         $posts = $this->postFactory(5);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -228,6 +228,11 @@ class Post extends Model
         'title', 'slug', 'body', 'author_id',
     ];
 
+    public function scopeFood($query)
+    {
+        $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
+    }
+
     public function author()
     {
         return $this->belongsTo(Author::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -233,6 +233,13 @@ class Post extends Model
         $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
     }
 
+    public function scopeFruit($query, $smth)
+    {
+        if ($smth === 'idoo') {
+            $query->whereIn('title', ['Apple']);
+        }
+    }
+
     public function author()
     {
         return $this->belongsTo(Author::class);


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request implements the ability to specify a [local Eloquent scope](https://laravel.com/docs/8.x/eloquent#local-scopes) with the Antlers tag provided by Runway.

## Example

```php
// app/Models/Post.php

public function scopeFood($query, $first, $second)
{
    // $first, $second

    $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
}

public function scopeHealthy($query)
{
    $query->whereIn('title', ['Apple']);
}
```

```antlers
{{ runway:post scope="food:arg1,arg2|healthy" }}
    <h2>{{ title }}</h2>
    <p>{{ intro_text }}</p>
{{ /runway:post }}
```

## To Do

* [X] Support for basic scopes
* [x] Support for scopes which require parameters
* [x] Possibly support for multiple scopes?

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Closes #82