### PR TITLE
GraphQL

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -25,6 +25,8 @@ GraphQL must be enabled for each of the resources you wish to query. It's as sim
 
 You must also ensure you have [GraphQL enabled](https://statamic.dev/graphql#enable-graphql) in Statamic as well for it to be available to you.
 
+> As a side note, please ensure you've installed the `doctrine/dbal` package, Runway uses it for reviewing your database columns. To install it, run `composer require doctrine/dbal`
+
 ## Queries
 
 For each resource, there's two kinds of queries you can do. An 'index' query and a 'show' query:

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,0 +1,83 @@
+---
+title: GraphQL
+---
+
+GraphQL is an awesome way to fetch just the right information you need from your backend. It's commonly used in 'headless' environments.
+
+Statamic includes a read-only [GraphQL API](https://statamic.dev/graphql) out of the box. Runway extends upon this so you can query your Eloquent models.
+
+## Enabling for resources
+
+GraphQL must be enabled for each of the resources you wish to query. It's as simple as adding to your config:
+
+```php
+// config/runway.php
+
+'resources' => [
+    \App\Models\Product::class => [
+        'name' => 'Products',
+        'blueprint' => 'product',
+
+        'graphql' => true,
+    ],
+],
+```
+
+You must also ensure you have [GraphQL enabled](https://statamic.dev/graphql#enable-graphql) in Statamic as well for it to be available to you.
+
+## Queries
+
+For each resource, there's two kinds of queries you can do. An 'index' query and a 'show' query.
+
+### Index Query
+
+Example of an index query:
+
+```graphql
+{
+    products {
+        data {
+            id
+            name
+            price
+            description
+        }
+    }
+}
+```
+
+An index query also allows for pagination between results, you can read up more on that in the [Statamic Documentation](https://statamic.dev/graphql#pagination).
+
+### Show Query
+
+Example of a show query:
+
+```graphql
+{
+    products(id: 2) {
+        id
+        name
+        price
+        description
+    }
+}
+```
+
+## Relationships
+
+If you're using the 'Belongs To' or 'Has Many' fieldtypes provided by Runway, you can also query the related models.
+
+```graphql
+{
+  product(id: 2) {
+    id
+    name
+    brand_id {
+      id
+      name
+      created_at
+      updated_at
+    }
+  }
+}
+```

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -27,7 +27,7 @@ You must also ensure you have [GraphQL enabled](https://statamic.dev/graphql#ena
 
 ## Queries
 
-For each resource, there's two kinds of queries you can do. An 'index' query and a 'show' query.
+For each resource, there's two kinds of queries you can do. An 'index' query and a 'show' query:
 
 ### Index Query
 
@@ -72,7 +72,7 @@ If you're using the 'Belongs To' or 'Has Many' fieldtypes provided by Runway, yo
   product(id: 2) {
     id
     name
-    brand_id {
+    brand {
       id
       name
       created_at
@@ -81,3 +81,9 @@ If you're using the 'Belongs To' or 'Has Many' fieldtypes provided by Runway, yo
   }
 }
 ```
+
+Notice that in the above example, we have a 'Belongs To' fieldtype which we're querying as simply `brand`, instead of `brand_id`. Runway removes the `_id` for you so you can build a nice, clean query.
+
+## Filtering and Sorting
+
+You may also filter & sort results the same way you would with the built-in queries. [Review the Statamic Docs](https://statamic.dev/graphql#filtering).

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -56,7 +56,7 @@ Example of a show query:
 
 ```graphql
 {
-    products(id: 2) {
+    products(id: "2") {
         id
         name
         price
@@ -71,7 +71,7 @@ If you're using the 'Belongs To' or 'Has Many' fieldtypes provided by Runway, yo
 
 ```graphql
 {
-  product(id: 2) {
+  product(id: "2") {
     id
     name
     brand {

--- a/src/Fieldtypes/BelongsToFieldtype.php
+++ b/src/Fieldtypes/BelongsToFieldtype.php
@@ -2,6 +2,9 @@
 
 namespace DoubleThreeDigital\Runway\Fieldtypes;
 
+use DoubleThreeDigital\Runway\Runway;
+use Statamic\Facades\GraphQL;
+
 class BelongsToFieldtype extends BaseFieldtype
 {
     protected function configFieldItems(): array
@@ -17,5 +20,12 @@ class BelongsToFieldtype extends BaseFieldtype
         ];
 
         return array_merge($config, parent::configFieldItems());
+    }
+
+    public function toGqlType()
+    {
+        $resource = Runway::findResource($this->config('resource'));
+
+        return GraphQL::type("runway.graphql.types.{$resource->handle()}");
     }
 }

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -3,6 +3,8 @@
 namespace DoubleThreeDigital\Runway\Fieldtypes;
 
 use DoubleThreeDigital\Runway\Runway;
+use GraphQL\Type\Definition\ResolveInfo;
+use Statamic\Facades\GraphQL;
 
 class HasManyFieldtype extends BaseFieldtype
 {
@@ -75,5 +77,17 @@ class HasManyFieldtype extends BaseFieldtype
             });
 
         return null;
+    }
+
+    public function toGqlType()
+    {
+        $resource = Runway::findResource($this->config('resource'));
+
+        return [
+            'type' => GraphQL::listOf(GraphQL::type("runway.graphql.types.{$resource->handle()}")),
+            'resolve' => function ($model, $args, $context, ResolveInfo $info) use ($resource) {
+                return $model->{$info->fieldName};
+            },
+        ];
     }
 }

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -9,9 +9,12 @@ use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Queries\Query;
 use Illuminate\Support\Str;
 use Statamic\GraphQL\Types\JsonArgument;
+use Statamic\Tags\Concerns\QueriesConditions;
 
 class ResourceIndexQuery extends Query
 {
+    use QueriesConditions;
+
     protected $resource;
 
     public function __construct(Resource $resource)
@@ -63,18 +66,19 @@ class ResourceIndexQuery extends Query
                 })->values()->all();
             }
 
-            // ray($definitions);
 
             foreach ($definitions as $definition) {
                 $condition = array_keys($definition)[0];
                 $value = array_values($definition)[0];
 
-                // Statamic has a `QueriesConditions` class where it does this stuff
-                // but since we need to query slighly differently, we've just done
-                // it ourselves.
+                // The plan is to use the QueriesConditions method soon but I'm
+                // just waiting on a PR to be merged first... so until then,
+                // I'll do the queries myself
+                //
+                // https://github.com/statamic/cms/pull/4312
 
-                // If you need any of the conditions I've missed out, please PR
-                // them or open an issue.
+                // $query = $this->queryCondition($query, $field, $condition, $value);
+
                 switch ($condition) {
                     case 'equals':
                         $query = $query->where($field, $value);

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\GraphQL;
+
+use DoubleThreeDigital\Runway\Resource;
+use GraphQL\Type\Definition\Type;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Queries\Query;
+use Illuminate\Support\Str;
+
+class ResourceIndexQuery extends Query
+{
+    protected $resource;
+
+    public function __construct(Resource $resource)
+    {
+        $this->resource = $resource;
+        $this->attributes['name'] = Str::lower($resource->plural());
+    }
+
+    public function type(): Type
+    {
+        return GraphQL::paginate(GraphQL::type("runway.graphql.types.{$this->resource->handle()}"));
+    }
+
+    public function args(): array
+    {
+        return [
+            'limit' => GraphQL::int(),
+            'page' => GraphQL::int(),
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        return $this->resource->model()->paginate(
+            $args['limit'] ?? null,
+            ['*'],
+            'page',
+            $args['page'] ?? null
+        );
+    }
+}

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -31,6 +31,7 @@ class ResourceIndexQuery extends Query
             'limit' => GraphQL::int(),
             'page' => GraphQL::int(),
             'filter' => GraphQL::type(JsonArgument::NAME),
+            'sort' => GraphQL::listOf(GraphQL::string()),
         ];
     }
 
@@ -39,6 +40,7 @@ class ResourceIndexQuery extends Query
         $query = $this->resource->model();
 
         $query = $this->filterQuery($query, $args['filter'] ?? []);
+        $query = $this->sortQuery($query, $args['sort'] ?? []);
 
         return $query->paginate(
             $args['limit'] ?? null,
@@ -157,6 +159,25 @@ class ResourceIndexQuery extends Query
                         break;
                 }
             }
+        }
+
+        return $query;
+    }
+
+    protected function sortQuery($query, $sorts)
+    {
+        if (empty($sorts)) {
+            $sorts = ['id'];
+        }
+
+        foreach ($sorts as $sort) {
+            $order = 'asc';
+
+            if (Str::contains($sort, ' ')) {
+                [$sort, $order] = explode(' ', $sort);
+            }
+
+            $query = $query->orderBy($sort, $order);
         }
 
         return $query;

--- a/src/GraphQL/ResourceShowQuery.php
+++ b/src/GraphQL/ResourceShowQuery.php
@@ -26,13 +26,12 @@ class ResourceShowQuery extends Query
     public function args(): array
     {
         return [
-            'id' => GraphQL::nonNull(GraphQL::int()),
+            $this->resource->primaryKey() => GraphQL::nonNull(GraphQL::id()),
         ];
     }
 
     public function resolve($root, $args)
     {
-        // TODO: make work with different foreign keys
-        return $this->resource->model()->find($args['id']);
+        return $this->resource->model()->find($args[$this->resource->primaryKey()]);
     }
 }

--- a/src/GraphQL/ResourceShowQuery.php
+++ b/src/GraphQL/ResourceShowQuery.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\GraphQL;
+
+use DoubleThreeDigital\Runway\Resource;
+use GraphQL\Type\Definition\Type;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Queries\Query;
+use Illuminate\Support\Str;
+
+class ResourceShowQuery extends Query
+{
+    protected $resource;
+
+    public function __construct(Resource $resource)
+    {
+        $this->resource = $resource;
+        $this->attributes['name'] = Str::lower($resource->singular());
+    }
+
+    public function type(): Type
+    {
+        return GraphQL::type("runway.graphql.types.{$this->resource->handle()}");
+    }
+
+    public function args(): array
+    {
+        return [
+            'id' => GraphQL::nonNull(GraphQL::int()),
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        // TODO: make work with different foreign keys
+        return $this->resource->model()->find($args['id']);
+    }
+}

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -60,6 +60,10 @@ class ResourceType extends Type
                     $type = GraphQL::int();
                 }
 
+                if ($column->getType() instanceof \Doctrine\DBAL\Types\StringType) {
+                    $type = GraphQL::string();
+                }
+
                 if ($column->getType() instanceof \Doctrine\DBAL\Types\DateTimeType) {
                     // return new DateField;
                     $type = GraphQL::string();

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\Runway\Resource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
 use Statamic\Facades\GraphQL;
-use Statamic\GraphQL\Fields\DateField;
 use Rebing\GraphQL\Support\Type;
 
 class ResourceType extends Type
@@ -21,6 +20,8 @@ class ResourceType extends Type
 
     public function fields(): array
     {
+        ray($this->resource->blueprint()->fields()->toGql());
+
         return $this->resource->blueprint()->fields()->toGql()
             ->merge($this->nonBlueprintFields())
             ->map(function ($arr) {
@@ -30,6 +31,7 @@ class ResourceType extends Type
 
                 return $arr;
             })
+            ->ray()
             ->all();
     }
 
@@ -65,7 +67,6 @@ class ResourceType extends Type
                 }
 
                 if ($column->getType() instanceof \Doctrine\DBAL\Types\DateTimeType) {
-                    // return new DateField;
                     $type = GraphQL::string();
                 }
 

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway\GraphQL;
 
 use DoubleThreeDigital\Runway\Resource;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Fields\DateField;
 use Rebing\GraphQL\Support\Type;
@@ -21,15 +22,13 @@ class ResourceType extends Type
     public function fields(): array
     {
         return $this->resource->blueprint()->fields()->toGql()
-            ->merge([
-                'id' => ['type' => GraphQL::nonNull(GraphQL::int())],
-                // 'created_at' => new DateField,
-                // 'updated_at' => new DateField,
-            ])
-            ->map(function ($item) {
-                return array_merge($item, [
-                    'resolve' => $this->resolver(),
-                ]);
+            ->merge($this->nonBlueprintFields())
+            ->map(function ($arr) {
+                if (is_array($arr)) {
+                    $arr['resolve'] = $arr['resolve'] ?? $this->resolver();
+                }
+
+                return $arr;
             })
             ->all();
     }
@@ -39,5 +38,41 @@ class ResourceType extends Type
         return function (Model $model, $args, $context, $info) {
             return $model->{$info->fieldName};
         };
+    }
+
+    protected function nonBlueprintFields(): array
+    {
+        $columns = Schema::getConnection()
+            ->getDoctrineSchemaManager()
+            ->listTableColumns($this->resource->databaseTable());
+
+        return collect($columns)
+            ->reject(function ($column) {
+                return in_array(
+                    $column->getName(),
+                    $this->resource->blueprint()->fields()->all()->keys()->toArray()
+                );
+            })
+            ->map(function ($column) {
+                $type = null;
+
+                if ($column->getType() instanceof \Doctrine\DBAL\Types\BigIntType) {
+                    $type = GraphQL::int();
+                }
+
+                if ($column->getType() instanceof \Doctrine\DBAL\Types\DateTimeType) {
+                    // return new DateField;
+                    $type = GraphQL::string();
+                }
+
+                if ($column->getNotnull() === true && ! is_null($type)) {
+                    $type = GraphQL::nonNull($type);
+                }
+
+                return [
+                    'type' => $type,
+                ];
+            })
+            ->toArray();
     }
 }

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Schema;
 use Statamic\Facades\GraphQL;
 use Rebing\GraphQL\Support\Type;
 use Illuminate\Support\Str;
+use Statamic\Fields\Field;
 
 class ResourceType extends Type
 {
@@ -25,6 +26,11 @@ class ResourceType extends Type
     {
         return $this->resource->blueprint()->fields()->toGql()
             ->merge($this->nonBlueprintFields())
+            ->mapWithKeys(function ($value, $key) {
+                return [
+                    Str::replace('_id', '', $key) => $value
+                ];
+            })
             ->map(function ($arr) {
                 if (is_array($arr)) {
                     $arr['resolve'] = $arr['resolve'] ?? $this->resolver();

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\GraphQL;
+
+use DoubleThreeDigital\Runway\Resource;
+use Illuminate\Database\Eloquent\Model;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Fields\DateField;
+use Rebing\GraphQL\Support\Type;
+
+class ResourceType extends Type
+{
+    protected $resource;
+
+    public function __construct(Resource $resource)
+    {
+        $this->resource = $resource;
+        $this->attributes['name'] = "runway.graphql.types.{$resource->handle()}";
+    }
+
+    public function fields(): array
+    {
+        return $this->resource->blueprint()->fields()->toGql()
+            ->merge([
+                'id' => ['type' => GraphQL::nonNull(GraphQL::int())],
+                // 'created_at' => new DateField,
+                // 'updated_at' => new DateField,
+            ])
+            ->map(function ($item) {
+                return array_merge($item, [
+                    'resolve' => $this->resolver(),
+                ]);
+            })
+            ->all();
+    }
+
+    protected function resolver()
+    {
+        return function (Model $model, $args, $context, $info) {
+            return $model->{$info->fieldName};
+        };
+    }
+}

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -77,6 +77,9 @@ class ResourceType extends Type
                     'type' => $type,
                 ];
             })
+            ->reject(function ($item) {
+                return is_null($item['type']);
+            })
             ->toArray();
     }
 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -20,6 +20,7 @@ class Resource
     protected $route;
     protected $template;
     protected $layout;
+    protected $graphqlEnabled;
 
     public function handle($handle = null)
     {
@@ -135,6 +136,15 @@ class Resource
         return $this->fluentlyGetOrSet('layout')
             ->getter(function ($value) {
                 return $value ?? 'layout';
+            })
+            ->args(func_get_args());
+    }
+
+    public function graphqlEnabled($graphqlEnabled = null)
+    {
+        return $this->fluentlyGetOrSet('graphqlEnabled')
+            ->getter(function ($graphqlEnabled) {
+                return $graphqlEnabled ?? false;
             })
             ->args(func_get_args());
     }

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -55,6 +55,10 @@ class Runway
                     $resource->layout($config['layout']);
                 }
 
+                if (isset($config['graphql'])) {
+                    $resource->graphqlEnabled($config['graphql']);
+                }
+
                 return [$handle => $resource];
             })
             ->toArray();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -116,11 +116,6 @@ class ServiceProvider extends AddonServiceProvider
                     return new \DoubleThreeDigital\Runway\GraphQL\ResourceShowQuery($resource);
                 });
 
-                // $this->app->bind("runway.graphql.types.{$resource->handle()}", function () use ($resource) {
-                //     return new \DoubleThreeDigital\Runway\GraphQL\ResourceType($resource);
-                // });
-
-                // GraphQL::addType("runway.graphql.types.{$resource->handle()}");
                 GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.index");
                 GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.show");
             });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -113,7 +113,6 @@ class ServiceProvider extends AddonServiceProvider
                     return new \DoubleThreeDigital\Runway\GraphQL\ResourceType($resource);
                 });
 
-                // TODO: Add docblocks to this facade in core
                 GraphQL::addType("runway.graphql.types.{$resource->handle()}");
                 GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.index");
                 GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.show");

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\Runway;
 
 use Statamic\Facades\CP\Nav;
+use Statamic\Facades\GraphQL;
 use Statamic\Facades\Permission;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
@@ -59,6 +60,7 @@ class ServiceProvider extends AddonServiceProvider
             Runway::discoverResources();
 
             $this->registerPermissions();
+            $this->bootGraphQl();
 
             if (Runway::usesRouting()) {
                 $this->app->get(\Statamic\Contracts\Data\DataRepository::class)
@@ -91,5 +93,30 @@ class ServiceProvider extends AddonServiceProvider
                 ]);
             })->group('Runway');
         }
+    }
+
+    protected function bootGraphQl()
+    {
+        Runway::allResources()
+            ->filter
+            ->graphqlEnabled()
+            ->each(function (Resource $resource) {
+                $this->app->bind("runway.graphql.queries.{$resource->handle()}.index", function () use ($resource) {
+                    return new \DoubleThreeDigital\Runway\GraphQL\ResourceIndexQuery($resource);
+                });
+
+                $this->app->bind("runway.graphql.queries.{$resource->handle()}.show", function () use ($resource) {
+                    return new \DoubleThreeDigital\Runway\GraphQL\ResourceShowQuery($resource);
+                });
+
+                $this->app->bind("runway.graphql.types.{$resource->handle()}", function () use ($resource) {
+                    return new \DoubleThreeDigital\Runway\GraphQL\ResourceType($resource);
+                });
+
+                // TODO: Add docblocks to this facade in core
+                GraphQL::addType("runway.graphql.types.{$resource->handle()}");
+                GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.index");
+                GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.show");
+            });
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,6 +98,13 @@ class ServiceProvider extends AddonServiceProvider
     protected function bootGraphQl()
     {
         Runway::allResources()
+            ->each(function (Resource $resource) {
+                $this->app->bind("runway.graphql.types.{$resource->handle()}", function () use ($resource) {
+                    return new \DoubleThreeDigital\Runway\GraphQL\ResourceType($resource);
+                });
+
+                GraphQL::addType("runway.graphql.types.{$resource->handle()}");
+            })
             ->filter
             ->graphqlEnabled()
             ->each(function (Resource $resource) {
@@ -109,11 +116,11 @@ class ServiceProvider extends AddonServiceProvider
                     return new \DoubleThreeDigital\Runway\GraphQL\ResourceShowQuery($resource);
                 });
 
-                $this->app->bind("runway.graphql.types.{$resource->handle()}", function () use ($resource) {
-                    return new \DoubleThreeDigital\Runway\GraphQL\ResourceType($resource);
-                });
+                // $this->app->bind("runway.graphql.types.{$resource->handle()}", function () use ($resource) {
+                //     return new \DoubleThreeDigital\Runway\GraphQL\ResourceType($resource);
+                // });
 
-                GraphQL::addType("runway.graphql.types.{$resource->handle()}");
+                // GraphQL::addType("runway.graphql.types.{$resource->handle()}");
                 GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.index");
                 GraphQL::addQuery("runway.graphql.queries.{$resource->handle()}.show");
             });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Rebing\GraphQL\GraphQLServiceProvider;
 use Statamic\Extend\Manifest;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Stache\Stores\UsersStore;
@@ -38,6 +39,7 @@ abstract class TestCase extends OrchestraTestCase
     protected function getPackageProviders($app)
     {
         return [
+            GraphQLServiceProvider::class,
             StatamicServiceProvider::class,
             ServiceProvider::class,
         ];


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces the ability to query your Runway resources/models with GraphQL.

## Enabling

GraphQL won't be enabled on resources by default, it'll have to be explicitly enabled with a simple config setting:

```php
// config/runway.php

'resources' => [
  \App\Models\Product::class => [
    'name' => 'Products',
    'blueprint' => 'product',

    'graphql' => true,
  ],
],
```

## Example Query

```graphql
{
  products {
    data {
      id
      name
      slug
      price
    }
  },
  product(id: 4) {
    name
    price
  }
}
```

## To Do

* [X] Base GQL Queries
* [X] Base GQL Type
* [x] Better way of deal with IDs and other non-blueprint columns
* [x] Figure out why queries are not showing in GraphiQL Explorer
* [x] Write a new 'GraphQL' page in the documentation (add to Oxygen once merged)
* [x] Support for the BelongsTo fieldtype
* [x] Support for the HasMany fieldtype
* [x] Add support for filtering
* [x] Add support for sorting

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Closes #54