### PR TITLE
Fix Statamic search when using HasMany fieldtype

### DIFF
--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -24,7 +24,7 @@ class ResourceListingController extends CpController
             abort(403);
         }
 
-        $sortField     = $request->input('sort', $resource->primaryKey());
+        $sortField = $request->input('sort', $resource->primaryKey());
         $sortDirection = $request->input('order', 'ASC');
 
         $query = $resource->model()
@@ -33,7 +33,7 @@ class ResourceListingController extends CpController
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'collection' => $resourceHandle,
             'blueprints' => [
-                $blueprint
+                $blueprint,
             ],
         ]);
 


### PR DESCRIPTION
## Description

If you have a `has_many` field in your resource, the CP search throws an error about that field is not a valid column (which is true).

At the moment this PR only filters out the `has_many` fields from the blueprint so the search works. I made a `searchableFields` so that this can be cleaned up and expanded as not all fields should be searchable (like asset paths etc). Perhaps it should use the "search index" feature of Statamic so that we can include/exclude/write transformers so that our Models can be searchable? Or maybe use a package like this: https://github.com/nicolaslopezj/searchable ?

I didn't have time to write tests yet, sorry. Making this PR so I can pull it in via composer patch.

HMU on discord to discuss how you'd like me to handle