### PR TITLE
Fix search on resources with HasMany field

### DIFF
--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -93,18 +93,12 @@ class ResourceListingController extends CpController
 
     private function addLikeSearch(Blueprint $blueprint, string $searchQuery, Builder $query): void
     {
-        foreach ($this->searchableFields($blueprint) as $field) {
+        $searchableFields = $blueprint->fields()->items()->reject(function (array $field) {
+            return $field['field']['type'] === 'has_many';
+        });
+
+        foreach ($searchableFields as $field) {
             $query->orWhere($field['handle'], 'LIKE', '%' . $searchQuery . '%');
         }
-    }
-
-    private function searchableFields(Blueprint $blueprint): Collection
-    {
-        return $blueprint
-            ->fields()
-            ->items()
-            ->reject(function (array $field) {
-                return $field['field']['type'] == 'has_many';
-            });
     }
 }

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -24,7 +24,7 @@ class ResourceListingController extends CpController
             abort(403);
         }
 
-        $sortField     = $request->input('sort', $resource->primaryKey());
+        $sortField = $request->input('sort', $resource->primaryKey());
         $sortDirection = $request->input('order', 'ASC');
 
         $query = $resource->model()
@@ -33,7 +33,7 @@ class ResourceListingController extends CpController
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'collection' => $resourceHandle,
             'blueprints' => [
-                $blueprint
+                $blueprint,
             ],
         ]);
 

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -47,7 +47,13 @@ class ResourceListingController extends CpController
                     $query->runwaySearch($searchQuery);
                 },
                 function ($query) use ($searchQuery, $blueprint) {
-                    $this->addLikeSearch($blueprint, $searchQuery, $query);
+                    $searchableFields = $blueprint->fields()->items()->reject(function (array $field) {
+                        return $field['field']['type'] === 'has_many';
+                    });
+
+                    foreach ($searchableFields as $field) {
+                        $query->orWhere($field['handle'], 'LIKE', '%' . $searchQuery . '%');
+                    }
                 }
             );
         }
@@ -89,16 +95,5 @@ class ResourceListingController extends CpController
                 ];
             })
             ->toArray();
-    }
-
-    private function addLikeSearch(Blueprint $blueprint, string $searchQuery, Builder $query): void
-    {
-        $searchableFields = $blueprint->fields()->items()->reject(function (array $field) {
-            return $field['field']['type'] === 'has_many';
-        });
-
-        foreach ($searchableFields as $field) {
-            $query->orWhere($field['handle'], 'LIKE', '%' . $searchQuery . '%');
-        }
     }
 }

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
 
+use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Statamic\Facades\User;
 
 class ResourceListingControllerTest extends TestCase
@@ -75,6 +77,53 @@ class ResourceListingControllerTest extends TestCase
                         'edit_url' => 'http://localhost/cp/runway/post/'.$posts[0]->id,
                         'delete_url' => 'http://localhost/cp/runway/post/'.$posts[0]->id,
                         'id' => $posts[0]->id,
+                    ],
+                ],
+            ]);
+    }
+
+    /** @test */
+    public function can_search_records_with_has_many_relationship()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields', [
+            [
+                'handle' => 'name',
+                'field' => [
+                    'type' => 'text',
+                ],
+            ],
+            [
+                'handle' => 'posts',
+                'field' => [
+                    'type' => 'has_many',
+                    'resource' => 'post',
+                    'mode' => 'select',
+                ],
+            ],
+        ]);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $author = $this->authorFactory(1, ['name' => 'Colin The Caterpillar']);
+
+        $posts = $this->postFactory(5, ['author_id' => $author->id]);
+
+        $this->actingAs($user)
+            ->get(cp_route('runway.listing-api', [
+                'resourceHandle' => 'author',
+                'search' => 'Colin',
+                'columns' => 'name,posts',
+            ]))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    [
+                        'name' => 'Colin The Caterpillar',
+                        'edit_url' => 'http://localhost/cp/runway/author/'.$author->id,
+                        'delete_url' => 'http://localhost/cp/runway/author/'.$author->id,
+                        'id' => $author->id,
                     ],
                 ],
             ]);


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

If a resource has a HasMany fieldtype on it and you try to search for one of it's records, you would previously get an error. This pull request fixes the issue so HasMany fields are not searched upon (since it does some magic under the hood and isn't an actual database column).

This didn't seem to be an issue for SQLite which seemed to silence the exception.

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Replaces #99
