### PR TITLE
proper permission checks

### DIFF
--- a/src/Http/Requests/DestroyRequest.php
+++ b/src/Http/Requests/DestroyRequest.php
@@ -12,7 +12,7 @@ class DestroyRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
-        return User::current()->hasPermission("Delete {$resource->plural()}")
+        return User::current()->hasPermission("Delete {$resource->singular()}")
             || User::current()->isSuper();
     }
 

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -12,7 +12,7 @@ class StoreRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
-        return User::current()->hasPermission("Create new {$resource->plural()}")
+        return User::current()->hasPermission("Create new {$resource->singular()}")
             || User::current()->isSuper();
     }
 


### PR DESCRIPTION
## Description

The permissions for `store` and `destroy` are singular but the checks in the requests were plural, which caused an `Authorization failed` error.