### PR TITLE
Feature: Allow HasMany to work on Stache entries

### DIFF
--- a/docs/fieldtypes.md
+++ b/docs/fieldtypes.md
@@ -20,6 +20,8 @@ Also when configuring the fieldtype, you may choose the resource you wish to be 
 
 This fieldtype allows you to select multiple models for a `hasMany` or `morphedByMany` Eloquent relationship.
 
+> Fun fact: You can use the HasMany fieldtype anywhere - in Runway resources, entries, taxonomies, you name it!
+
 ### Configuration
 
 It’s important that when configuring this fieldtype, the handle of the field is the same as the name of the `hasMany` relationship, eg: `authors`.

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -31,8 +31,9 @@ class HasManyFieldtype extends BaseFieldtype
     {
         $resourceHandle = request()->route('resourceHandle');
 
-        if (!$resourceHandle)
-            return $data;       
+        if (! $resourceHandle) {
+            return $data;      
+        }
         
         return collect($data)
             ->pluck('id')
@@ -44,8 +45,9 @@ class HasManyFieldtype extends BaseFieldtype
     {
         $resourceHandle = request()->route('resourceHandle');
 
-        if (!$resourceHandle)
-            return $data;        
+        if (! $resourceHandle) {
+            return $data;      
+        }      
         
         $resource = Runway::findResource($resourceHandle);
         $record = $resource->model()->firstWhere($resource->routeKey(), (int) Request::route('record'));

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -29,6 +29,7 @@ class HasManyFieldtype extends BaseFieldtype
     // Pre-process the data before it gets sent to the publish page
     public function preProcess($data)
     {
+        // Determine whether or not this field is on a resource or a collection
         $resourceHandle = request()->route('resourceHandle');
 
         if (! $resourceHandle) {
@@ -43,6 +44,7 @@ class HasManyFieldtype extends BaseFieldtype
     // Process the data before it gets saved
     public function process($data)
     {
+        // Determine whether or not this field is on a resource or a collection
         $resourceHandle = request()->route('resourceHandle');
 
         if (! $resourceHandle) {

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -32,9 +32,9 @@ class HasManyFieldtype extends BaseFieldtype
         $resourceHandle = request()->route('resourceHandle');
 
         if (! $resourceHandle) {
-            return $data;      
+            return $data;
         }
-        
+
         return collect($data)
             ->pluck('id')
             ->toArray();
@@ -46,9 +46,9 @@ class HasManyFieldtype extends BaseFieldtype
         $resourceHandle = request()->route('resourceHandle');
 
         if (! $resourceHandle) {
-            return $data;      
-        }      
-        
+            return $data;
+        }
+
         $resource = Runway::findResource($resourceHandle);
         $record = $resource->model()->firstWhere($resource->routeKey(), (int) Request::route('record'));
 

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -29,6 +29,11 @@ class HasManyFieldtype extends BaseFieldtype
     // Pre-process the data before it gets sent to the publish page
     public function preProcess($data)
     {
+        $resourceHandle = request()->route('resourceHandle');
+
+        if (!$resourceHandle)
+            return $data;       
+        
         return collect($data)
             ->pluck('id')
             ->toArray();
@@ -37,7 +42,12 @@ class HasManyFieldtype extends BaseFieldtype
     // Process the data before it gets saved
     public function process($data)
     {
-        $resource = Runway::findResource(request()->route('resourceHandle'));
+        $resourceHandle = request()->route('resourceHandle');
+
+        if (!$resourceHandle)
+            return $data;        
+        
+        $resource = Runway::findResource($resourceHandle);
         $record = $resource->model()->firstWhere($resource->routeKey(), (int) Request::route('record'));
 
         // If we're adding HasMany relations on a model that doesn't exist yet,

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -8,7 +8,6 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Request;
 use Statamic\Fields\Field;
 
 class HasManyFieldtypeTest extends TestCase


### PR DESCRIPTION
## Description

Basically we by-pass all the logic you wrote and only run it if resourceHandle is available in the route, which it isnt on Stache entries.

This then allows the normal relationship field logic to run and the items get inserted as ids in the yaml array.

## Related Issues

None
