### PR TITLE
Performance Tweaks

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -5,6 +5,7 @@ title: Templating
 There’s no point storing data in a database for it never to be used, is there?
 
 ## Tags
+
 Runway provides a `{{ runway }}` Antlers tag to enable you to get model data for your resources.
 
 For example, if you wish to create a listing/index page for a resource, you can use the tag like shown below:
@@ -19,6 +20,7 @@ For example, if you wish to create a listing/index page for a resource, you can 
 There’s a bunch of helpful parameters you can use on the tag as well…
 
 ### Sorting
+
 You may use the `sort` parameter to adjust the order of the results.
 
 ```antlers
@@ -29,6 +31,7 @@ You may use the `sort` parameter to adjust the order of the results.
 ```
 
 ### Eloquent Scopes
+
 If you've defined a scope on your Eloquent model and you want to filter by that in your front-end you may use the `scope` parameter.
 
 ```php
@@ -62,6 +65,7 @@ You may also provide multiple scopes, if that's something you need...
 ```
 
 ### Filtering
+
 Just like with the collection tag, you may filter your results like so:
 
 ```antlers
@@ -72,6 +76,7 @@ Just like with the collection tag, you may filter your results like so:
 ```
 
 ### Eager Loading
+
 If your model has a relationship that you'd like to bring into the template, you may specify the `with` parameter.
 
 ```antlers
@@ -87,7 +92,10 @@ You can specify multiple relationships to eager load, just separate with pipes.
 {{ runway:post with="user|comments" }}
 ```
 
+> Hot Tip: Eager Loading can make a **massive** difference in the speed of your queries.
+
 ### Limiting
+
 If you only want X number of results returned instead of ALL of them, you may specify a `limit`.
 
 ```antlers
@@ -98,6 +106,7 @@ If you only want X number of results returned instead of ALL of them, you may sp
 ```
 
 ### Scoping
+
 As [with the collection tag](https://statamic.dev/tags/collection#scope), you may use the `as` parameter to scope your results.
 
 ```antlers
@@ -110,6 +119,7 @@ As [with the collection tag](https://statamic.dev/tags/collection#scope), you ma
 ```
 
 ### Pagination
+
 If you want to paginate your results onto multiple pages, you can use the `paginate` parameter, along with [scoping](#scoping) and [limiting](#limiting).
 
 Using the Runway tag with pagination is a little more complicated but it’s not rocket science.
@@ -140,6 +150,7 @@ Using the Runway tag with pagination is a little more complicated but it’s not
 ```
 
 ## Augmentation
+
 All the results output from the Runway tag are ‘augmented’, which essentially means everything is the same as you’d expect if you had the same data in an entry.
 
 The process of augmentation takes a value (from the database in our case) and processes it via the fieldtype into a value appropriate for the front-end.

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -42,6 +42,23 @@ class ResourceIndexQuery extends Query
     {
         $query = $this->resource->model()->newQuery();
 
+        if ($this->resource->hasRouting()) {
+            $query->with('runwayUri');
+        }
+
+        $this->resource->blueprint()->fields()->items()->filter(function ($field) {
+            return $field['field']['type'] === 'belongs_to'
+                || $field['field']['type'] === 'has_many';
+        })->map(function ($field) {
+            if (str_contains($field['handle'], '_id')) {
+                return str_replace('_id', '', $field['handle']);
+            }
+
+            return $field['handle'];
+        })->each(function ($relation) use (&$query) {
+            $query->with($relation);
+        });
+
         $this->filterQuery($query, $args['filter'] ?? []);
         $this->sortQuery($query, $args['sort'] ?? []);
 
@@ -56,7 +73,7 @@ class ResourceIndexQuery extends Query
     protected function filterQuery($query, $filters)
     {
         foreach ($filters as $field => $definitions) {
-            if (! is_array($definitions)) {
+            if (!is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];
             }
 

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -46,18 +46,19 @@ class ResourceIndexQuery extends Query
             $query->with('runwayUri');
         }
 
-        $this->resource->blueprint()->fields()->items()->filter(function ($field) {
-            return $field['field']['type'] === 'belongs_to'
-                || $field['field']['type'] === 'has_many';
-        })->map(function ($field) {
-            if (str_contains($field['handle'], '_id')) {
-                return str_replace('_id', '', $field['handle']);
-            }
+        $this->resource->blueprint()->fields()->items()
+            ->filter(function ($field) {
+                return $field['field']['type'] === 'belongs_to'
+                    || $field['field']['type'] === 'has_many';
+            })->map(function ($field) {
+                if (str_contains($field['handle'], '_id')) {
+                    return str_replace('_id', '', $field['handle']);
+                }
 
-            return $field['handle'];
-        })->each(function ($relation) use (&$query) {
-            $query->with($relation);
-        });
+                return $field['handle'];
+            })->each(function ($relation) use (&$query) {
+                $query->with($relation);
+            });
 
         $this->filterQuery($query, $args['filter'] ?? []);
         $this->sortQuery($query, $args['sort'] ?? []);

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -29,6 +29,10 @@ class ResourceListingController extends CpController
         $query = $resource->model()
             ->orderBy($sortField, $sortDirection);
 
+        if ($resource->hasRouting()) {
+            $query->with('runwayUri');
+        }
+
         $blueprint->fields()->items()->filter(function ($field) {
             return $field['field']['type'] === 'belongs_to'
                 || $field['field']['type'] === 'has_many';

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -33,18 +33,19 @@ class ResourceListingController extends CpController
             $query->with('runwayUri');
         }
 
-        $blueprint->fields()->items()->filter(function ($field) {
-            return $field['field']['type'] === 'belongs_to'
-                || $field['field']['type'] === 'has_many';
-        })->map(function ($field) {
-            if (str_contains($field['handle'], '_id')) {
-                return str_replace('_id', '', $field['handle']);
-            }
+        $blueprint->fields()->items()
+            ->filter(function ($field) {
+                return $field['field']['type'] === 'belongs_to'
+                    || $field['field']['type'] === 'has_many';
+            })->map(function ($field) {
+                if (str_contains($field['handle'], '_id')) {
+                    return str_replace('_id', '', $field['handle']);
+                }
 
-            return $field['handle'];
-        })->each(function ($relation) use (&$query) {
-            $query->with($relation);
-        });
+                return $field['handle'];
+            })->each(function ($relation) use (&$query) {
+                $query->with($relation);
+            });
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'collection' => $resourceHandle,

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -64,6 +64,8 @@ class ResourceCollection extends LaravelResourceCollection
                     }
 
                     if ($this->runwayResource->blueprint()->hasField($key)) {
+                        // If we've eager loaded in relationships, just pass in the model
+                        // instance. We can save extra queries this way.
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof BelongsToFieldtype) {
                             $relationName = str_replace('_id', '', $key);
 


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request introduces eager loading behind the scenes for 'index queries' made by Runway. This will almost certainly fix #113.

Big thanks to @DanielDarrenJones for pairing with me on this one!

## Changes made

Runway will now automatically ['eager load'](https://laravel.com/docs/8.x/eloquent-relationships#eager-loading) relations for any Runway fieldtypes (Belongs To & Has Many), along with the 'runwayUri` relation if front-end routing has been enabled.

## Before

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/19637309/152645639-33eacdf3-5827-45d1-95de-7b221effe253.png">

## After

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/19637309/152645625-7713a4c5-87dc-4587-93b0-a66dcda8d8e8.png">

## Runway Tag

This PR doesn't touch the Runway tag as it already allows for developers to specify which models they'd like to eager load in the query.

```antlers
{{ runway:product with="tags|brand|runwayUri" }}
    <h2><a href="{{ url }}">{{ name }}</a></h2>
{{ /runway:product }}
```

When we tested the impact of adding the eager loading parameter to the tag, we saw great improvements in terms of number of queries and speed. To encourage the use of the `with` parameter, I've added a 'Hot Tip' note to the documentation.