### PR TITLE
Fix issue with Eager Loading

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,4 @@
 preset: laravel
 risky: false
-enabled:
-  - concat_with_spaces
+disabled:
+  - concat_without_spaces

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,6 @@
 preset: laravel
 risky: false
+enabled:
+  - concat_with_spaces
 disabled:
   - cast_spaces

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,5 +2,3 @@ preset: laravel
 risky: false
 enabled:
   - concat_with_spaces
-disabled:
-  - cast_spaces

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -84,7 +84,7 @@ class ResourceIndexQuery extends Query
     protected function filterQuery($query, $filters)
     {
         foreach ($filters as $field => $definitions) {
-            if (!is_array($definitions)) {
+            if (! is_array($definitions)) {
                 $definitions = [['equals' => $definitions]];
             }
 

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -42,6 +42,20 @@ class ResourceIndexQuery extends Query
     {
         $query = $this->resource->model()->newQuery();
 
+        $this->eagerLoadQuery($query);
+        $this->filterQuery($query, $args['filter'] ?? []);
+        $this->sortQuery($query, $args['sort'] ?? []);
+
+        return $query->paginate(
+            $args['limit'] ?? null,
+            ['*'],
+            'page',
+            $args['page'] ?? null
+        );
+    }
+
+    protected function eagerLoadQuery($query)
+    {
         $this->resource->blueprint()->fields()->items()
             ->filter(function ($field) {
                 return $field['field']['type'] === 'belongs_to'
@@ -65,16 +79,6 @@ class ResourceIndexQuery extends Query
             ->each(function ($relationName) use (&$query) {
                 $query->with($relationName);
             });
-
-        $this->filterQuery($query, $args['filter'] ?? []);
-        $this->sortQuery($query, $args['sort'] ?? []);
-
-        return $query->paginate(
-            $args['limit'] ?? null,
-            ['*'],
-            'page',
-            $args['page'] ?? null
-        );
     }
 
     protected function filterQuery($query, $filters)

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -9,6 +9,7 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
+use Illuminate\Support\Str;
 
 class ResourceListingController extends CpController
 {
@@ -19,7 +20,7 @@ class ResourceListingController extends CpController
         $resource = Runway::findResource($resourceHandle);
         $blueprint = $resource->blueprint();
 
-        if (! User::current()->hasPermission("View {$resource->plural()}") && ! User::current()->isSuper()) {
+        if (!User::current()->hasPermission("View {$resource->plural()}") && !User::current()->isSuper()) {
             abort(403);
         }
 
@@ -29,22 +30,28 @@ class ResourceListingController extends CpController
         $query = $resource->model()
             ->orderBy($sortField, $sortDirection);
 
-        if ($resource->hasRouting()) {
-            $query->with('runwayUri');
-        }
-
         $blueprint->fields()->items()
             ->filter(function ($field) {
                 return $field['field']['type'] === 'belongs_to'
                     || $field['field']['type'] === 'has_many';
-            })->map(function ($field) {
+            })
+            ->map(function ($field) {
                 if (str_contains($field['handle'], '_id')) {
                     return str_replace('_id', '', $field['handle']);
                 }
 
+                if (str_contains($field['handle'], '_')) {
+                    return Str::camel($field['handle']);
+                }
+
                 return $field['handle'];
-            })->each(function ($relation) use (&$query) {
-                $query->with($relation);
+            })
+            ->merge(['runwayUri'])
+            ->filter(function ($relationName) use ($resource) {
+                return method_exists($resource->model(), $relationName);
+            })
+            ->each(function ($relationName) use (&$query) {
+                $query->with($relationName);
             });
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
@@ -64,7 +71,7 @@ class ResourceListingController extends CpController
                     $blueprint->fields()->items()->reject(function (array $field) {
                         return $field['field']['type'] === 'has_many';
                     })->each(function (array $field) use ($query, $searchQuery) {
-                        $query->orWhere($field['handle'], 'LIKE', '%'.$searchQuery.'%');
+                        $query->orWhere($field['handle'], 'LIKE', '%' . $searchQuery . '%');
                     });
                 }
             );
@@ -76,7 +83,7 @@ class ResourceListingController extends CpController
 
         return (new ResourceCollection($results))
             ->setResourceHandle($resourceHandle)
-            ->setColumnPreferenceKey('runway.'.$resourceHandle.'.columns')
+            ->setColumnPreferenceKey('runway.' . $resourceHandle . '.columns')
             ->setColumns($columns)
             ->additional(['meta' => [
                 'activeFilterBadges' => $activeFilterBadges,

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -5,11 +5,11 @@ namespace DoubleThreeDigital\Runway\Http\Controllers;
 use DoubleThreeDigital\Runway\Http\Resources\ResourceCollection;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
+use Illuminate\Support\Str;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
-use Illuminate\Support\Str;
 
 class ResourceListingController extends CpController
 {
@@ -20,7 +20,7 @@ class ResourceListingController extends CpController
         $resource = Runway::findResource($resourceHandle);
         $blueprint = $resource->blueprint();
 
-        if (!User::current()->hasPermission("View {$resource->plural()}") && !User::current()->isSuper()) {
+        if (! User::current()->hasPermission("View {$resource->plural()}") && ! User::current()->isSuper()) {
             abort(403);
         }
 


### PR DESCRIPTION
This pull request fixes two issues brought about by the introduction of eager loading (#114) the other day:

### 1. Case where field handle is different from relation name

If the handle of your BelongsTo/HasMany _(mostly for HasMany's though, since we strip `_id` from the end of field handles)_ field was different from that of your relation name, you would run into an issue where Runway would try to eager load a relationship that didn't exist.

* Relation name: `supportConversations`
* Field handle: `support_conversations`

```
[2022-02-08 10:39:16] local.ERROR: Call to undefined relationship [support_conversations] on model [App\Models\Customer]. {"userId":"cba0aed3-26f9-4ca9-a67f-8261a605d37b","exception":"[object] (Illuminate\\Database\\Eloquent\\RelationNotFoundException(code: 0): Call to undefined relationship [support_conversations] on model [App\\Models\\Orphan]. at /Users/duncan/Sites/runway-sandbox.test/vendor/laravel/framework/src/Illuminate/Database/Eloquent/RelationNotFoundException.php:35)
[stacktrace]
```

### 2. The case where a relationship doesn't exist

This one sort of follows on from the last case. Essentially, if Runway ends up with the wrong 'relation name' at some point, it will attempt to eager load it which won't work and will throw an error.

Eager Loading is done magically by Runway, without users even knowing. Because of this, I think the best course of action would be to silently fail if a relation doesn't actually exist.

## Related issues

Fixes #116