### PR TITLE
Eager Loading: Improve 'magic relation guessing'

### DIFF
--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Http\Resources\Json\ResourceCollection as LaravelResourceCollection;
+use Illuminate\Support\Str;
 use Statamic\Facades\Action;
 use Statamic\Facades\User;
 
@@ -68,6 +69,7 @@ class ResourceCollection extends LaravelResourceCollection
                         // instance. We can save extra queries this way.
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof BelongsToFieldtype) {
                             $relationName = str_replace('_id', '', $key);
+                            $relationName = Str::camel($relationName);
 
                             if ($record->relationLoaded($relationName)) {
                                 $value = $record->$relationName;

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -68,6 +68,8 @@ class ResourceCollection extends LaravelResourceCollection
                         // If we've eager loaded in relationships, just pass in the model
                         // instance. We can save extra queries this way.
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof BelongsToFieldtype) {
+                            // TODO: refactor this to use the 'magic relation guessing' from the
+                            // Resource's `eagerLoadingRelations` method.
                             $relationName = str_replace('_id', '', $key);
                             $relationName = Str::camel($relationName);
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request will fix an issue where multi-word relationships wouldn't be getting eager loaded properly. We weren't `Str::camel` casing the multiple words.

Before this fix, you'd end up with the eager loading itself actually working BUT you'd also see a whole load of extra (n+1) queries happening, as if we weren't even using eager loading.