### PR TITLE
Refactor eager loading magic ✨ 

### DIFF
--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -42,7 +42,7 @@ class ResourceIndexQuery extends Query
     {
         $query = $this->resource->model()
             ->newQuery()
-            ->with($this->resource->eagerLoadingRelations());
+            ->with($this->resource->eagerLoadingRelations()->values()->all());
 
         $this->filterQuery($query, $args['filter'] ?? []);
         $this->sortQuery($query, $args['sort'] ?? []);

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -29,7 +29,7 @@ class ResourceListingController extends CpController
         $query = $resource->model()
             ->orderBy($sortField, $sortDirection);
 
-        $query->with($resource->eagerLoadingRelations());
+        $query->with($resource->eagerLoadingRelations()->values()->all());
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'collection' => $resourceHandle,

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -6,7 +6,6 @@ use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Http\Resources\Json\ResourceCollection as LaravelResourceCollection;
-use Illuminate\Support\Str;
 use Statamic\Facades\Action;
 use Statamic\Facades\User;
 
@@ -68,10 +67,7 @@ class ResourceCollection extends LaravelResourceCollection
                         // If we've eager loaded in relationships, just pass in the model
                         // instance. We can save extra queries this way.
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof BelongsToFieldtype) {
-                            // TODO: refactor this to use the 'magic relation guessing' from the
-                            // Resource's `eagerLoadingRelations` method.
-                            $relationName = str_replace('_id', '', $key);
-                            $relationName = Str::camel($relationName);
+                            $relationName = $this->runwayResource->eagerLoadingRelations()->get($key);
 
                             if ($record->relationLoaded($relationName)) {
                                 $value = $record->$relationName;

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -159,7 +159,7 @@ class Resource
                             return $field['field']['type'] === 'belongs_to'
                                 || $field['field']['type'] === 'has_many';
                         })
-                        ->map(function ($field) {
+                        ->mapWithKeys(function ($field) {
                             $relationName = $field['handle'];
 
                             if (str_contains($relationName, '_id')) {
@@ -170,16 +170,15 @@ class Resource
                                 $relationName = Str::camel($relationName);
                             }
 
-                            return $relationName;
+                            return [$field['handle'] => $relationName];
                         })
                         ->merge(['runwayUri'])
                         ->filter(function ($relationName) {
                             return method_exists($this->model(), $relationName);
-                        })
-                        ->toArray();
+                        });
                 }
 
-                return $eagerLoadingRelations;
+                return collect($eagerLoadingRelations);
             })
             ->args(func_get_args());
     }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests;
+
+use DoubleThreeDigital\Runway\Runway;
+use Illuminate\Support\Facades\Config;
+
+class ResourceTest extends TestCase
+{
+    /** @test */
+    public function can_get_eager_loading_relations_for_belongs_to_field()
+    {
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+
+        $this->assertContains('author', $eagerLoadingRelations->toArray());
+    }
+
+    /** @test */
+    public function can_get_eager_loading_relations_for_has_many_field()
+    {
+        $fields = Config::get('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields');
+
+        $fields[] = [
+            'handle' => 'posts',
+            'field' => [
+                'type' => 'has_many',
+                'resource' => 'post',
+                'max_items' => 1,
+                'mode' => 'default',
+            ],
+        ];
+
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields', $fields);
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('author');
+
+        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+
+        $this->assertContains('posts', $eagerLoadingRelations->toArray());
+    }
+
+    /** @test */
+    public function can_get_eager_loading_relations_for_runway_uri_routing()
+    {
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+
+        $this->assertContains('runwayUri', $eagerLoadingRelations->toArray());
+    }
+
+    /** @test */
+    public function can_get_eager_loading_relations_as_defined_in_config()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.with', ['author']);
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+
+        $this->assertContains('author', $eagerLoadingRelations->toArray());
+        $this->assertNotContains('runwayUri', $eagerLoadingRelations->toArray());
+    }
+}


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request refactors the way Runway gets the relation names which should be eager loaded in the CP & via GraphQL. This PR also includes some tests for the magic logic that we provide.

## To Do

* [X] Refactor logic to use single method in `Runway`
* [x] Added some tests
