### PR TITLE
Store models in blink to prevent multiple DB calls

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\Runway\Fieldtypes;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\CP\Column;
+use Statamic\Facades\Blink;
 use Statamic\Fieldtypes\Relationship;
 
 class BaseFieldtype extends Relationship
@@ -141,7 +142,9 @@ class BaseFieldtype extends Relationship
 
             ->map(function ($record) use ($resource) {
                 if (! $record instanceof Model) {
-                    $record = $resource->model()->firstWhere($resource->primaryKey(), $record);
+                    $record = Blink::once('runway-'.$this->config('resource').'-'.$record, function() use ($resource, $record) {
+                        return $resource->model()->firstWhere($resource->primaryKey(), $record);
+                    });
                 }
 
                 return $resource->augment($record);

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -142,7 +142,7 @@ class BaseFieldtype extends Relationship
 
             ->map(function ($record) use ($resource) {
                 if (! $record instanceof Model) {
-                    $record = Blink::once('runway-'.$this->config('resource').'-'.$record, function () use ($resource, $record) {
+                    $record = Blink::once("Runway::{$this->config('resource')}::{$record}", function () use ($resource, $record) {
                         return $resource->model()->firstWhere($resource->primaryKey(), $record);
                     });
                 }

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -142,7 +142,7 @@ class BaseFieldtype extends Relationship
 
             ->map(function ($record) use ($resource) {
                 if (! $record instanceof Model) {
-                    $record = Blink::once('runway-'.$this->config('resource').'-'.$record, function() use ($resource, $record) {
+                    $record = Blink::once('runway-'.$this->config('resource').'-'.$record, function () use ($resource, $record) {
                         return $resource->model()->firstWhere($resource->primaryKey(), $record);
                     });
                 }


### PR DESCRIPTION
This is a performance related PR. We are using runway on a site that often outputs the same items on a page. Instead of getting them each time, lets `Blink` them so we only do one database query per model on the front end.
