### PR TITLE
Update Resource.php

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -156,8 +156,10 @@ class Resource
                 if (! $eagerLoadingRelations) {
                     return $this->blueprint()->fields()->items()
                         ->filter(function ($field) {
-                            return $field['field']['type'] === 'belongs_to'
-                                || $field['field']['type'] === 'has_many';
+                            $type = $field['field']['type'] ?? null;
+
+                            return $type === 'belongs_to'
+                                || $type === 'has_many';
                         })
                         ->mapWithKeys(function ($field) {
                             $relationName = $field['handle'];


### PR DESCRIPTION
In some cases the field could be something like `- import: address` or some other fieldset, and the field type key doesn't exist.
This produces a warning, and therefore an error in strict environments.

This PR fixes it
