### PR TITLE
'Read Only' Resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -185,6 +185,19 @@ You may also specify the `template` and `layout` you want to use when front-end 
 ],
 ```
 
+### Read Only
+
+You may also specify if you want a resource to be 'read only' - eg. users will not be able to create records and when editing, all fields will be marked as read only and no save button will be displayed.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+        'read_only' => true,
+	],
+],
+```
+
 ## Actions
 
 In much the same way with entries, you can create custom Actions which will be usable in the listing tables provided by Runway.

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -13,7 +13,7 @@
         </div>
       </h1>
 
-      <div class="hidden md:flex items-center">
+      <div v-if="!readOnly" class="hidden md:flex items-center">
         <button class="btn-primary" :disabled="isSaving" @click.prevent="save">
           Save
         </button>
@@ -85,6 +85,7 @@ export default {
     permalink: String,
     isCreating: Boolean,
     publishContainer: String,
+    readOnly: Boolean,
   },
 
   data() {
@@ -93,8 +94,6 @@ export default {
       values: this.initialValues,
       meta: this.initialMeta,
       title: this.initialTitle,
-
-      readonly: false, // TODO: might do this in the future
 
       errors: {},
       saving: false,

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -15,6 +15,7 @@
         permalink="{{ $permalink }}"
         :is-creating="false"
         publish-container="base"
+        :read-only="{{ $resource->readOnly() ? 'true' : 'false' }}"
     ></runway-publish-form>
 
     <script>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -6,14 +6,16 @@
     <div class="flex items-center justify-between mb-3">
         <h1 class="flex-1">{{ $title }}</h1>
 
-        @can('Create new ' . $resource->singular())
-            <a
-                class="btn-primary"
-                href="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"
-            >
-                Create {{ $resource->singular() }}
-            </a>
-        @endcan
+        @if(! $resource->readOnly())
+            @can('Create new ' . $resource->singular())
+                <a
+                    class="btn-primary"
+                    href="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"
+                >
+                    Create {{ $resource->singular() }}
+                </a>
+            @endcan
+        @endif
     </div>
 
     @if ($recordCount > 0)

--- a/src/Actions/DeleteModel.php
+++ b/src/Actions/DeleteModel.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Actions;
 
+use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Actions\Action;
@@ -17,7 +18,9 @@ class DeleteModel extends Action
 
     public function visibleTo($item)
     {
-        return $item instanceof Model;
+        return $item instanceof Model
+            && ($resource = Runway::findResourceByModel($item)) instanceof Resource
+            && $resource->readOnly() !== true;
     }
 
     public function visibleToBulk($items)
@@ -39,13 +42,13 @@ class DeleteModel extends Action
 
     public function buttonText()
     {
-        /** @translation */
+        /* @translation */
         return 'Delete|Delete :count items?';
     }
 
     public function confirmationText()
     {
-        /** @translation */
+        /* @translation */
         return 'Are you sure you want to want to delete this?|Are you sure you want to delete these :count items?';
     }
 

--- a/src/Http/Requests/CreateRequest.php
+++ b/src/Http/Requests/CreateRequest.php
@@ -12,6 +12,10 @@ class CreateRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
+        if ($resource->readOnly()) {
+            return false;
+        }
+
         return User::current()->hasPermission("Create new {$resource->singular()}")
             || User::current()->isSuper();
     }

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -12,6 +12,10 @@ class StoreRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
+        if ($resource->readOnly()) {
+            return false;
+        }
+
         return User::current()->hasPermission("Create new {$resource->singular()}")
             || User::current()->isSuper();
     }

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -12,6 +12,10 @@ class UpdateRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
+        if ($resource->readOnly()) {
+            return false;
+        }
+
         return User::current()->hasPermission("Edit {$resource->plural()}")
             || User::current()->isSuper();
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -21,6 +21,8 @@ class Resource
     protected $template;
     protected $layout;
     protected $graphqlEnabled;
+    protected $readOnly;
+    protected $eagerLoadingRelations;
 
     public function handle($handle = null)
     {
@@ -146,6 +148,12 @@ class Resource
             ->getter(function ($graphqlEnabled) {
                 return $graphqlEnabled ?? false;
             })
+            ->args(func_get_args());
+    }
+
+    public function readOnly($readOnly = null)
+    {
+        return $this->fluentlyGetOrSet('readOnly')
             ->args(func_get_args());
     }
 

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -58,6 +58,10 @@ class Runway
                     $resource->graphqlEnabled($config['graphql']);
                 }
 
+                if (isset($config['read_only'])) {
+                    $resource->readOnly($config['read_only']);
+                }
+
                 if (isset($config['with'])) {
                     $resource->eagerLoadingRelations($config['with']);
                 }

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -51,7 +51,7 @@ class ResourceControllerTest extends TestCase
 
         $this->actingAs($user)
             ->get(cp_route('runway.create', ['resourceHandle' => 'post']))
-            ->assertForbidden();
+            ->assertRedirect();
     }
 
     /** @test */
@@ -74,6 +74,31 @@ class ResourceControllerTest extends TestCase
             ]);
 
         $this->assertDatabaseHas('posts', [
+            'title' => 'Jingle Bells',
+        ]);
+    }
+
+    /** @test */
+    public function cant_store_resource_if_resource_is_read_only()
+    {
+        Config::set('runway.resources.' . Post::class . '.read_only', true);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $author = $this->authorFactory();
+
+        $this->actingAs($user)
+            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+                'title' => 'Jingle Bells',
+                'slug' => 'jingle-bells',
+                'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
+                'author_id' => [$author->id],
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('posts', [
             'title' => 'Jingle Bells',
         ]);
     }
@@ -215,6 +240,24 @@ class ResourceControllerTest extends TestCase
     }
 
     /** @test */
+    public function can_edit_resource_if_resource_is_read_only()
+    {
+        Config::set('runway.resources.' . Post::class . '.read_only', true);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $post = $this->postFactory();
+
+        $this->actingAs($user)
+            ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
+            ->assertOk()
+            ->assertSee($post->title)
+            ->assertSee($post->body);
+    }
+
+    /** @test */
     public function can_update_resource()
     {
         $user = User::make()->makeSuper()->save();
@@ -236,6 +279,31 @@ class ResourceControllerTest extends TestCase
         $post->refresh();
 
         $this->assertSame($post->title, 'Santa is coming home');
+    }
+
+    /** @test */
+    public function cant_update_resource_if_resource_is_read_only()
+    {
+        Config::set('runway.resources.' . Post::class . '.read_only', true);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $post = $this->postFactory();
+
+        $this->actingAs($user)
+            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+                'title' => 'Santa is coming home',
+                'slug' => 'santa-is-coming-home',
+                'body' => $post->body,
+                'author_id' => [$post->author_id],
+            ])
+            ->assertRedirect();
+
+        $post->refresh();
+
+        $this->assertNotSame($post->title, 'Santa is coming home');
     }
 
     /** @test */

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -41,6 +41,20 @@ class ResourceControllerTest extends TestCase
     }
 
     /** @test */
+    public function cant_create_resource_if_resource_is_read_only()
+    {
+        Config::set('runway.resources.' . Post::class . '.read_only', true);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $this->actingAs($user)
+            ->get(cp_route('runway.create', ['resourceHandle' => 'post']))
+            ->assertForbidden();
+    }
+
+    /** @test */
     public function can_store_resource()
     {
         $user = User::make()->makeSuper()->save();


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request introduces the ability to mark resources as 'read only'. With a read-only resource, users won't be able to create new records & won't be able to make changes when editing existing records.

## To Do

* [X] Added the `read_only` config option
* [X] Guard against going directly to create/edit routes if resource is marked as read only
* [x] Added tests
* [X] Updated the documentation
