### PR TITLE
Customisations around CP Nav Items

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -138,9 +138,13 @@ If you’d like to hide the CP Nav Item that’s registered for this model, just
 
 > Bear in mind, this will just hide the Nav Item for the CP interface, it won’t actually get rid of the routes being registered. If someone knows where to look, they could still use the CP to manage your models (they could guess the URL).
 
-### CP Nav Icon
+## CP Nav
 
-When Runway registers the CP Nav Item, it uses a rather generic icon. If you’d like to customise this, set `cp_icon` to the name of the icon you’d like to use instead.
+Runway will automatically register a Control Panel Nav Item for any configured resources (unless they're marked as `hidden`). By default, it'll put them in the 'Content' section and give them a generic icon. However, you may configure various settings for the CP Nav Item if required:
+
+### Icon
+
+You should set `icon` to the name of the icon you’d like to use instead.
 
 Alternatively, if the icon you want isn’t [included in Statamic](https://github.com/statamic/cms/tree/3.1/resources/svg), you can also pass an SVG inline.
 
@@ -148,9 +152,42 @@ Alternatively, if the icon you want isn’t [included in Statamic](https://githu
 'resources' => [
 	\App\Models\Order::class => [
 		'name' => 'Orders',
-    	'listing' => [
-      		'cp_icon' => 'date',
-    	],
+
+        'nav' => [
+            'icon' => 'date',
+        ],
+	],
+],
+```
+
+### Section
+
+You should set `section` to the name of the section you’d like to use instead.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+		'name' => 'Orders',
+
+        'nav' => [
+            'section' => 'Tools',
+        ],
+	],
+],
+```
+
+### Title
+
+You should set `title` to whatever you want the name of the Nav Item to be.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+		'name' => 'Orders',
+
+        'nav' => [
+            'title' => 'Shop Orders',
+        ],
 	],
 ],
 ```

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -16,6 +16,8 @@ class Resource
     protected $name;
     protected $blueprint;
     protected $cpIcon;
+    protected $cpSection;
+    protected $cpTitle;
     protected $hidden;
     protected $route;
     protected $template;
@@ -91,6 +93,32 @@ class Resource
             ->getter(function ($value) {
                 if (! $value) {
                     return file_get_contents(__DIR__ . '/../resources/svg/database.svg');
+                }
+
+                return $value;
+            })
+            ->args(func_get_args());
+    }
+
+    public function cpSection($cpSection = null)
+    {
+        return $this->fluentlyGetOrSet('cpSection')
+            ->getter(function ($value) {
+                if (! $value) {
+                    return __('Content');
+                }
+
+                return $value;
+            })
+            ->args(func_get_args());
+    }
+
+    public function cpTitle($cpTitle = null)
+    {
+        return $this->fluentlyGetOrSet('cpTitle')
+            ->getter(function ($value) {
+                if (! $value) {
+                    return $this->name();
                 }
 
                 return $value;

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -34,8 +34,18 @@ class Runway
                     $resource->blueprint($config['blueprint']);
                 }
 
-                if (isset($config['listing']['cp_icon'])) {
+                if (isset($config['nav']['icon'])) {
+                    $resource->cpIcon($config['nav']['icon']);
+                } elseif (isset($config['listing']['cp_icon'])) {
                     $resource->cpIcon($config['listing']['cp_icon']);
+                }
+
+                if (isset($config['nav']['section'])) {
+                    $resource->cpSection($config['nav']['section']);
+                }
+
+                if (isset($config['nav']['title'])) {
+                    $resource->cpTitle($config['nav']['title']);
                 }
 
                 if (isset($config['hidden'])) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -93,7 +93,8 @@ class ServiceProvider extends AddonServiceProvider
                     continue;
                 }
 
-                $nav->content($resource->name())
+                $nav->content($resource->cpTitle())
+                    ->section($resource->cpSection())
                     ->icon($resource->cpIcon())
                     ->route('runway.index', ['resourceHandle' => $resource->handle()])
                     ->can("View {$resource->plural()}");


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request allows for better customisation around the Control Panel Nav Items that Runway registers for your resources (unless told otherwise).

You can now set a custom title and push the nav item into a section of your choice.

Related to #119

## To Do

* [X] Implemented better customisation
* [X] Updated the documentation
