### PR TITLE
Add limitRunwayQuery model to allow resources to be filtered/limited

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -61,9 +61,16 @@ class BaseFieldtype extends Relationship
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        return $resource->model()
-            ->orderBy($resource->primaryKey(), 'ASC')
-            ->get()
+        $model = $resource->model();
+        
+        $query = $model
+            ->orderBy($resource->primaryKey(), 'ASC');
+            
+        if (method_exists($model, 'limitRunwayQuery')) {
+            $model->limitRunwayQuery($query);
+        }
+                   
+        return $query->get()
             ->map(function ($record) use ($resource) {
                 $firstListableColumn = $resource->listableColumns()[0];
 

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -25,9 +25,15 @@ class ResourceListingController extends CpController
 
         $sortField = $request->input('sort', $resource->primaryKey());
         $sortDirection = $request->input('order', 'ASC');
+        
+        $model = $resource->model();
 
-        $query = $resource->model()
+        $query = $model
             ->orderBy($sortField, $sortDirection);
+            
+        if (method_exists($model, 'limitRunwayQuery')) {
+            $model->limitRunwayQuery($query);
+        }
 
         $query->with($resource->eagerLoadingRelations()->values()->all());
 


### PR DESCRIPTION
This PR adds support for a method to the index and field type listings that limits the results returned based on the developers requirements.

Our use case is we have a multi-site environment so we only want to return resources relevant to the site the user is editing. By providing this method we can filter the results.

## To Do

* [x] Made changes to the BaseFieldType and ResourceListingController files
* [ ] Added a test
* [ ] Updated the documentation

Haven't added tests or docs yet as I want to see if this is something you'd want to support.
