### PR TITLE
Ability to specify relationships to eager load when using Runway fieldtypes

### DIFF
--- a/docs/fieldtypes.md
+++ b/docs/fieldtypes.md
@@ -27,3 +27,5 @@ This fieldtype allows you to select multiple models for a `hasMany` or `morphedB
 It’s important that when configuring this fieldtype, the handle of the field is the same as the name of the `hasMany` relationship, eg: `authors`.
 
 Also when configuring the fieldtype, you may choose the resource you wish to be available for selection by the user.
+
+Optionally, you may also specify any relationships which should be eager loaded when the fieldtype is augmented (using the `with` config option).

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway\Fieldtypes;
 
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Statamic\CP\Column;
 use Statamic\Facades\Blink;
 use Statamic\Fieldtypes\Relationship;
@@ -58,6 +59,13 @@ class BaseFieldtype extends Relationship
                 'instructions' => __('statamic::fieldtypes.entries.config.create'),
                 'type' => 'toggle',
                 'default' => true,
+                'width' => 50,
+            ],
+            'with' => [
+                'display' => __('Eager Loaded Relationships'),
+                'instructions' => 'Specify any relationships you wish to be eager loaded when this field is augmented.',
+                'type' => 'list',
+                'default' => [],
                 'width' => 50,
             ],
         ];
@@ -170,7 +178,11 @@ class BaseFieldtype extends Relationship
             ->map(function ($record) use ($resource) {
                 if (! $record instanceof Model) {
                     $record = Blink::once("Runway::{$this->config('resource')}::{$record}", function () use ($resource, $record) {
-                        return $resource->model()->firstWhere($resource->primaryKey(), $record);
+                        return $resource->model()
+                            ->when($this->config('with'), function ($query) {
+                                $query->with(Arr::wrap($this->config('with')));
+                            })
+                            ->firstWhere($resource->primaryKey(), $record);
                     });
                 }
 


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request implements a new `with` config option for Runway fieldtypes so you can specify any relationships you wish to be eager loaded when the Runway field is augmented.

I've just ran into a case where I've needed this as otherwise, some of the information needed wouldn't be pulled in.

## To Do

* [x] Added the `with` config option to the list of config options
* [x] Made the `with` config option actually make the eager loading happen
* [x] Updated the documentation
