### PR TITLE
Correct behaviour of `runwaySearch` scope when searching in fieldtype

### DIFF
--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -50,7 +50,8 @@ class ResourceListingController extends CpController
                 },
                 function ($query) use ($searchQuery, $blueprint) {
                     $blueprint->fields()->items()->reject(function (array $field) {
-                        return $field['field']['type'] === 'has_many';
+                        return $field['field']['type'] === 'has_many'
+                            || $field['field']['type'] === 'hidden';
                     })->each(function (array $field) use ($query, $searchQuery) {
                         $query->orWhere($field['handle'], 'LIKE', '%' . $searchQuery . '%');
                     });


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 

  Also, if possible, record a quick screencast demo'ing your changes:
  https://zipmessage.com/nitcffb8
-->

This pull request fixes search in Runway's fieldtypes, when a `runwaySearch` scope is present on the resource's model. The behaviour is now the same as it is on the index listing table.

Now, if a `runwaySearch` scope exists, it'll be used, otherwise, it'll fallback to Runway's default search logic.

Fixes #149 