### PR TITLE
Use the formatted title on the item

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -240,7 +240,7 @@ class BaseFieldtype extends Relationship
 
         return [
             'id'    => $record->getKey(),
-            'title' => $record->{collect($resource->listableColumns())->first()},
+            'title' => $this->makeTitle($record, $resource),
             'edit_url' => $editUrl,
         ];
     }

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -62,8 +62,9 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertTrue($getIndexItems instanceof Collection);
         $this->assertSame($getIndexItems->count(), 2);
 
-        $this->assertSame($getIndexItems->first()['title'], 'AUTHOR ' . $authors[0]->name);
-        $this->assertSame($getIndexItems->last()['title'], 'AUTHOR ' . $authors[1]->name);
+        $this->assertSame($getIndexItems->first()['title'], 'AUTHOR '.$authors[0]->name);
+        $this->assertSame($getIndexItems->last()['title'], 'AUTHOR '.$authors[1]->name);
+    }
 
     /** @test */
     public function can_get_item_array_with_title_format()

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -64,6 +64,24 @@ class BelongsToFieldtypeTest extends TestCase
 
         $this->assertSame($getIndexItems->first()['title'], 'AUTHOR ' . $authors[0]->name);
         $this->assertSame($getIndexItems->last()['title'], 'AUTHOR ' . $authors[1]->name);
+
+    /** @test */
+    public function can_get_item_array_with_title_format()
+    {
+        $author = $this->authorFactory();
+
+        $this->fieldtype->setField(new Field('author', [
+            'max_items' => 1,
+            'mode' => 'default',
+            'resource' => 'author',
+            'display' => 'Author',
+            'type' => 'belongs_to',
+            'title_format' => 'AUTHOR {{ name }}',
+        ]));
+
+        $item = $this->fieldtype->getItemData([1]);
+
+        $this->assertSame($item->first()['title'], 'AUTHOR '.$author->name);
     }
 
     /** @test */

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -93,6 +93,30 @@ class HasManyFieldtypeTest extends TestCase
     }
 
     /** @test */
+    public function can_get_item_array_with_title_format()
+    {
+        $posts = $this->postFactory(2);
+        $author = $this->authorFactory();
+
+        foreach ($posts as $post) {
+            $post->update(['author_id' => $author->id]);
+        }
+
+        $this->fieldtype->setField(new Field('posts', [
+            'mode' => 'default',
+            'resource' => 'post',
+            'display' => 'Posts',
+            'type' => 'has_many',
+            'title_format' => '{{ title }} TEST {{ created_at format="Y" }}',
+        ]));
+
+        $item = $this->fieldtype->getItemData([$posts[0]->id, $posts[1]->id]);
+
+        $this->assertSame($item->first()['title'], $posts[0]->title . ' TEST ' . now()->format('Y'));
+        $this->assertSame($item->last()['title'], $posts[1]->title . ' TEST ' . now()->format('Y'));
+    }
+
+    /** @test */
     public function can_get_pre_process_index()
     {
         $posts = $this->postFactory(10);


### PR DESCRIPTION
Right now after you select an item, the title of it changes back to the previous behaviour (first listable column).

## To Do

* [x] Made change
* [x] Added a test
