### PR TITLE
Prevent error when attempting to augment model that doesn't exist

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -191,8 +191,13 @@ class BaseFieldtype extends Relationship
                     });
                 }
 
+                if (! $record) {
+                    return null;
+                }
+
                 return $resource->augment($record);
-            });
+            })
+            ->filter();
 
         if ($this->config('max_items') === 1) {
             return $result->first();


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request fixes #156 by preventing an error from happening when attempting to augment a model that doesn't exist (eg. when the model has been deleted but the reference is still there).

