### PR TITLE
Fix issues when using {{ nav:breadcrumbs }} tag on front-end routes

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -227,17 +227,17 @@ class Resource
             && in_array('DoubleThreeDigital\Runway\Routing\Traits\RunwayRoutes', class_uses($this->model()));
     }
 
-    public function primaryKey()
+    public function primaryKey(): string
     {
         return $this->model()->getKeyName();
     }
 
-    public function routeKey()
+    public function routeKey(): string
     {
         return $this->model()->getRouteKeyName() ?? 'id';
     }
 
-    public function databaseTable()
+    public function databaseTable(): string
     {
         return $this->model()->getTable();
     }
@@ -260,7 +260,7 @@ class Resource
         ];
     }
 
-    public function augment(Model $model)
+    public function augment(Model $model): array
     {
         return AugmentedRecord::augment($model, $this->blueprint());
     }


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request fixes #157, where you'd get an error about 'supplements' if you were to try and use the `{{ nav:breadcrumbs }}` tag on Runway's front-end routes.