### PR TITLE
Add config options to order models in Listing Tables

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -235,6 +235,22 @@ You may also specify if you want a resource to be 'read only' - eg. users will n
 ],
 ```
 
+### Ordering
+
+Sometimes you may want to change the order that your models are returned in the Control Panel listing table. You can use the `order_by` and `order_by_direction` configuration options to tell Runway the order you wish models to be returned.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+
+        // In this case, orders will the highest total will be displayed first.
+        'order_by' => 'total',
+        'order_by_direction' => 'DESC',
+	],
+],
+```
+
 ## Actions
 
 In much the same way with entries, you can create custom Actions which will be usable in the listing tables provided by Runway.

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -23,8 +23,8 @@ class ResourceListingController extends CpController
             abort(403);
         }
 
-        $sortField = $request->input('sort', $resource->primaryKey());
-        $sortDirection = $request->input('order', 'ASC');
+        $sortField = $request->input('sort', $resource->orderBy());
+        $sortDirection = $request->input('order', $resource->orderByDirection());
 
         $query = $resource->model()
             ->orderBy($sortField, $sortDirection);

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -25,6 +25,7 @@ class Resource
     protected $graphqlEnabled;
     protected $readOnly;
     protected $eagerLoadingRelations;
+    protected $orderBy;
 
     public function handle($handle = null)
     {
@@ -217,6 +218,32 @@ class Resource
                 }
 
                 return collect($eagerLoadingRelations);
+            })
+            ->args(func_get_args());
+    }
+
+    public function orderBy($orderBy = null)
+    {
+        return $this->fluentlyGetOrSet('orderBy')
+            ->getter(function ($value) {
+                if (! $value) {
+                    return $this->primaryKey();
+                }
+
+                return $value;
+            })
+            ->args(func_get_args());
+    }
+
+    public function orderByDirection($orderByDirection = null)
+    {
+        return $this->fluentlyGetOrSet('orderByDirection')
+            ->getter(function ($value) {
+                if (! $value) {
+                    return 'asc';
+                }
+
+                return $value;
             })
             ->args(func_get_args());
     }

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -76,6 +76,14 @@ class Runway
                     $resource->eagerLoadingRelations($config['with']);
                 }
 
+                if (isset($config['order_by'])) {
+                    $resource->orderBy($config['order_by']);
+                }
+
+                if (isset($config['order_by_direction'])) {
+                    $resource->orderByDirection($config['order_by_direction']);
+                }
+
                 return [$handle => $resource];
             })
             ->toArray();

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -51,9 +51,34 @@ class ResourceListingControllerTest extends TestCase
     }
 
     /** @test */
-    public function can_order_listing_rows()
+    public function listing_rows_are_ordered_as_per_config()
     {
-        $this->markTestIncomplete();
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.order_by', 'id');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.order_by_direction', 'desc');
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $posts = $this->postFactory(2);
+
+        $this->actingAs($user)
+            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    [
+                        'title' => $posts[1]->title,
+                        'edit_url' => 'http://localhost/cp/runway/post/' . $posts[1]->id,
+                        'id' => $posts[1]->id,
+                    ],
+                    [
+                        'title' => $posts[0]->title,
+                        'edit_url' => 'http://localhost/cp/runway/post/' . $posts[0]->id,
+                        'id' => $posts[0]->id,
+                    ],
+                ],
+            ]);
     }
 
     /** @test */

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -25,8 +25,6 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function can_sort_listing_rows()
     {
-        $this->markTestIncomplete();
-
         $user = User::make()->makeSuper()->save();
 
         $posts = $this->postFactory(2);


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request implements two new configuration options to Runway, allowing developers to specify the order in which they want models to be returned.

Previously, you would have to do something like this:

```php
public function scopeRunwayListing(Builder $query)
{
    return $query->reorder('price', 'asc');
}
```

Whereas now you can use these configuration options:

```php
'resources' => [
    \App\Models\Order::class => [
        'name' => 'Orders',

        // In this case, orders will the highest total will be displayed first.
        'order_by' => 'total',
        'order_by_direction' => 'DESC',
    ],
],
```

Closes #160

## To Do

* [X] Implemented new options
* [X] Updated the documentation
* [x] Added a test
