### PR TITLE
Use index fieldtypes in Runway stacks

### DIFF
--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,7 +1,18 @@
-import HasManyRelatedItem from './components/Fieldtypes/HasManyRelatedItem'
-import PublishForm from './components/Publish/PublishForm.vue'
-import ListingView from './components/Listing/ListingView.vue'
+import HasManyRelatedItem from "./components/Fieldtypes/HasManyRelatedItem";
+import PublishForm from "./components/Publish/PublishForm.vue";
+import ListingView from "./components/Listing/ListingView.vue";
 
-Statamic.$components.register('hasmany-related-item', HasManyRelatedItem)
-Statamic.$components.register('runway-publish-form', PublishForm)
-Statamic.$components.register('runway-listing-view', ListingView)
+Statamic.$components.register("hasmany-related-item", HasManyRelatedItem);
+Statamic.$components.register("runway-publish-form", PublishForm);
+Statamic.$components.register("runway-listing-view", ListingView);
+
+/**
+ * Pull in index fieldtypes (for reasons...)
+ */
+
+import HasManyFieldtypeIndex from "../../vendor/statamic/cms/resources/js/components/fieldtypes/relationship/RelationshipIndexFieldtype.vue";
+
+Statamic.$components.register(
+  "has_many-fieldtype-index",
+  HasManyFieldtypeIndex
+);


### PR DESCRIPTION
<!--
  Please provide an overview of what you've changed. 
  Maybe include a short demo video to go along with it? (https://www.loom.com/)
-->

This pull request fixes an issue where index fieldtypes wouldn't be used when displaying fields in a relationship stack.

For example, in the screenshot below, the product data would be shown as JSON text but now it correctly links to the products (as it does from the standard listing table).

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/19637309/182442499-ead28be6-4e4c-4455-b725-36a802a6774e.png">